### PR TITLE
Implement error handling for missing game ID

### DIFF
--- a/src/main/java/com/lollito/fm/bean/SessionBean.java
+++ b/src/main/java/com/lollito/fm/bean/SessionBean.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
+import com.lollito.fm.controller.rest.errors.GameNotFoundException;
 import com.lollito.fm.model.Game;
 import com.lollito.fm.repository.rest.GameRepository;
 
@@ -30,17 +31,10 @@ public class SessionBean {
 	}
 
 	public Game getGame() {
-		Game game = null;
 		if (this.gameId == null) {
-			// TODO error
-			logger.error("error - game is null");
-		} else {
-			game = gameRepository.findById(this.gameId).get();
-			if (game == null) {
-				// TODO error
-				logger.error("error - game is null");
-			}
+			throw new GameNotFoundException("Game ID is not set in session");
 		}
-		return game;
+		return gameRepository.findById(this.gameId)
+				.orElseThrow(() -> new GameNotFoundException("Game not found with ID: " + this.gameId));
 	}
 }

--- a/src/main/java/com/lollito/fm/controller/rest/errors/GameNotFoundException.java
+++ b/src/main/java/com/lollito/fm/controller/rest/errors/GameNotFoundException.java
@@ -1,0 +1,14 @@
+package com.lollito.fm.controller.rest.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class GameNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public GameNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/lollito/fm/bean/SessionBeanTest.java
+++ b/src/test/java/com/lollito/fm/bean/SessionBeanTest.java
@@ -1,0 +1,62 @@
+package com.lollito.fm.bean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.lollito.fm.controller.rest.errors.GameNotFoundException;
+import com.lollito.fm.model.Game;
+import com.lollito.fm.repository.rest.GameRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionBeanTest {
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @InjectMocks
+    private SessionBean sessionBean;
+
+    @Before
+    public void setUp() {
+    }
+
+    @Test(expected = GameNotFoundException.class)
+    public void getGame_throwsException_whenGameIdIsNull() {
+        sessionBean.setGameId(null);
+        sessionBean.getGame();
+    }
+
+    @Test(expected = GameNotFoundException.class)
+    public void getGame_throwsException_whenGameNotFound() {
+        Long gameId = 1L;
+        sessionBean.setGameId(gameId);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+        sessionBean.getGame();
+    }
+
+    @Test
+    public void getGame_returnsGame_whenFound() {
+        Long gameId = 1L;
+        Game game = new Game();
+        game.setId(gameId);
+
+        sessionBean.setGameId(gameId);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        Game result = sessionBean.getGame();
+
+        assertNotNull(result);
+        assertEquals(gameId, result.getId());
+    }
+}


### PR DESCRIPTION
Implemented proper error handling for missing `gameId` in `SessionBean.java`.
Previously, the code would log an error and return null (or crash with NoSuchElementException when calling `.get()` on empty Optional).
Now, it throws `GameNotFoundException` (mapped to HTTP 404) when:
1. `gameId` is not set in the session.
2. The game with the specified `gameId` is not found in the database.

Added unit tests in `SessionBeanTest.java` to verify these scenarios.

---
*PR created automatically by Jules for task [5625822293333248165](https://jules.google.com/task/5625822293333248165) started by @lollito*