### PR TITLE
Use specific exception when free club is not found

### DIFF
--- a/src/main/java/com/lollito/fm/service/ClubService.java
+++ b/src/main/java/com/lollito/fm/service/ClubService.java
@@ -16,6 +16,7 @@ import com.lollito.fm.model.Game;
 import com.lollito.fm.model.League;
 import com.lollito.fm.model.Stadium;
 import com.lollito.fm.repository.rest.ClubRepository;
+import com.lollito.fm.service.errors.FreeClubNotFoundException;
 import com.lollito.fm.utils.RandomUtils;
 
 @Service
@@ -58,8 +59,7 @@ public class ClubService {
 		return clubRepository.count();
 	}
 	
-	//TODO exception free club not found
 	public Club findTopByLeagueCountryAndUserIsNull(Country country) {
-		return clubRepository.findTopByLeagueCountryAndUserIsNull(country).orElseThrow();
+		return clubRepository.findTopByLeagueCountryAndUserIsNull(country).orElseThrow(FreeClubNotFoundException::new);
 	}
 }

--- a/src/main/java/com/lollito/fm/service/errors/FreeClubNotFoundException.java
+++ b/src/main/java/com/lollito/fm/service/errors/FreeClubNotFoundException.java
@@ -1,0 +1,9 @@
+package com.lollito.fm.service.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Free club not found")
+public class FreeClubNotFoundException extends RuntimeException {
+
+}

--- a/src/test/java/com/lollito/fm/service/ClubServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ClubServiceTest.java
@@ -1,0 +1,42 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Country;
+import com.lollito.fm.repository.rest.ClubRepository;
+import com.lollito.fm.service.errors.FreeClubNotFoundException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClubServiceTest {
+
+	@Mock
+	private ClubRepository clubRepository;
+
+	@InjectMocks
+	private ClubService clubService;
+
+	@Test(expected = FreeClubNotFoundException.class)
+	public void findTopByLeagueCountryAndUserIsNull_ShouldThrowException_WhenNoClubFound() {
+		when(clubRepository.findTopByLeagueCountryAndUserIsNull(any(Country.class))).thenReturn(Optional.empty());
+		clubService.findTopByLeagueCountryAndUserIsNull(new Country());
+	}
+
+	@Test
+	public void findTopByLeagueCountryAndUserIsNull_ShouldReturnClub_WhenClubFound() {
+		Club club = new Club();
+		when(clubRepository.findTopByLeagueCountryAndUserIsNull(any(Country.class))).thenReturn(Optional.of(club));
+		Club result = clubService.findTopByLeagueCountryAndUserIsNull(new Country());
+		assertNotNull(result);
+	}
+}


### PR DESCRIPTION
Replaced `orElseThrow()` with `orElseThrow(FreeClubNotFoundException::new)` in `ClubService.java` to provide a specific exception when a free club is not found.
Added `FreeClubNotFoundException` with `@ResponseStatus(HttpStatus.NOT_FOUND)`.
Added unit tests to verify the exception is thrown correctly and the happy path works.

---
*PR created automatically by Jules for task [18256128510025665085](https://jules.google.com/task/18256128510025665085) started by @lollito*