### PR TITLE
Implement scheduled game deletion logic

### DIFF
--- a/src/main/java/com/lollito/fm/ScheduledTasks.java
+++ b/src/main/java/com/lollito/fm/ScheduledTasks.java
@@ -3,6 +3,7 @@ package com.lollito.fm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.lollito.fm.service.GameService;
@@ -14,9 +15,9 @@ public class ScheduledTasks {
 	
 	@Autowired private GameService gameService;
 	
-//    @Scheduled(cron = "0 0/1 * * * ?")
-    public void reportCurrentTime() {
-    	logger.info("OOOEEEE");
-    	gameService.next();
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void deleteAllGames() {
+	logger.info("Deleting all games");
+	gameService.deleteAll();
     }
 }

--- a/src/main/java/com/lollito/fm/service/GameService.java
+++ b/src/main/java/com/lollito/fm/service/GameService.java
@@ -130,4 +130,8 @@ public class GameService {
 		//TODO security
 		gameRepository.deleteById(gameId);
 	}
+
+	public void deleteAll(){
+		gameRepository.deleteAll();
+	}
 }

--- a/src/test/java/com/lollito/fm/service/GameServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/GameServiceTest.java
@@ -1,0 +1,27 @@
+package com.lollito.fm.service;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.repository.rest.GameRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class GameServiceTest {
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @InjectMocks
+    private GameService gameService;
+
+    @Test
+    public void testDeleteAll() {
+        gameService.deleteAll();
+        verify(gameRepository).deleteAll();
+    }
+}


### PR DESCRIPTION
Implemented the scheduled game deletion logic as requested. 
The `ScheduledTasks.java` file had a TODO for deleting games in `reportCurrentTime` method.
This change replaces the method with `deleteAllGames` and enables the schedule to run at 1 AM daily.
It also adds the necessary `deleteAll` method in `GameService` and verifies it with a new unit test.

---
*PR created automatically by Jules for task [9624900289193946426](https://jules.google.com/task/9624900289193946426) started by @lollito*