### PR TITLE
Verify ID and Username in JWT generation

### DIFF
--- a/src/main/java/com/lollito/fm/config/security/jwt/JwtUtils.java
+++ b/src/main/java/com/lollito/fm/config/security/jwt/JwtUtils.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import com.lollito.fm.model.User;
+
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
@@ -35,6 +37,20 @@ public class JwtUtils {
 				.setSubject((userPrincipal.getUsername()))
 				.setIssuedAt(new Date())
 				.setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+				.signWith(key(), SignatureAlgorithm.HS256)
+				.compact();
+	}
+
+	public String generateJwtToken(User user) {
+		if (user.getId() == null || user.getUsername() == null) {
+			throw new IllegalArgumentException("User ID and Username cannot be null");
+		}
+
+		return Jwts.builder()
+				.setSubject(user.getUsername())
+				.setIssuedAt(new Date())
+				.setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+				.claim("userId", user.getId())
 				.signWith(key(), SignatureAlgorithm.HS256)
 				.compact();
 	}

--- a/src/main/java/com/lollito/fm/controller/rest/UserController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/UserController.java
@@ -49,7 +49,6 @@ public class UserController {
 				new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
 
 		SecurityContextHolder.getContext().setAuthentication(authentication);
-		String jwt = jwtUtils.generateJwtToken(authentication);
 
 		UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 		List<String> roles = userDetails.getAuthorities().stream()
@@ -57,6 +56,8 @@ public class UserController {
 				.collect(Collectors.toList());
 
 		User user = userService.findByUsernameAndActive(request.getUsername());
+
+		String jwt = jwtUtils.generateJwtToken(user);
 
 		return ResponseEntity.ok(new JwtResponse(jwt,
 												 user.getId(),
@@ -74,7 +75,7 @@ public class UserController {
 				new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
 
 		SecurityContextHolder.getContext().setAuthentication(authentication);
-		String jwt = jwtUtils.generateJwtToken(authentication);
+		String jwt = jwtUtils.generateJwtToken(user);
 
 		UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 		List<String> roles = userDetails.getAuthorities().stream()

--- a/src/test/java/com/lollito/fm/config/security/jwt/JwtUtilsTest.java
+++ b/src/test/java/com/lollito/fm/config/security/jwt/JwtUtilsTest.java
@@ -1,0 +1,70 @@
+package com.lollito.fm.config.security.jwt;
+
+import com.lollito.fm.model.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtUtilsTest {
+
+    private JwtUtils jwtUtils;
+    private String secret = "fmSecretKeyForFootballManagerProject2026DecoupledArchitecture";
+
+    @BeforeEach
+    void setUp() {
+        jwtUtils = new JwtUtils();
+        ReflectionTestUtils.setField(jwtUtils, "jwtSecret", secret);
+        ReflectionTestUtils.setField(jwtUtils, "jwtExpirationMs", 3600000);
+    }
+
+    @Test
+    void generateJwtToken_shouldThrowException_whenIdIsNull() {
+        User user = new User();
+        user.setUsername("testuser");
+        user.setId(null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            jwtUtils.generateJwtToken(user);
+        });
+    }
+
+    @Test
+    void generateJwtToken_shouldThrowException_whenUsernameIsNull() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername(null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            jwtUtils.generateJwtToken(user);
+        });
+    }
+
+    @Test
+    void generateJwtToken_shouldGenerateTokenWithUserIdClaim_whenUserIsValid() {
+        User user = new User();
+        user.setId(123L);
+        user.setUsername("testuser");
+
+        String token = jwtUtils.generateJwtToken(user);
+
+        assertNotNull(token);
+        assertTrue(jwtUtils.validateJwtToken(token));
+        assertEquals("testuser", jwtUtils.getUserNameFromJwtToken(token));
+
+        // Verify claim manually
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        Long userId = Jwts.parser().verifyWith(key).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("userId", Long.class);
+
+        assertEquals(123L, userId);
+    }
+}


### PR DESCRIPTION
Implemented ID and Username verification in JWT generation logic as requested. 

Changes:
- Modified `JwtUtils.java` to include a `generateJwtToken(User user)` method that throws `IllegalArgumentException` if ID or Username is null.
- The new method adds `userId` to the token claims.
- Updated `UserController.java` to use the new method in `login` and `registration` endpoints.
- Added `JwtUtilsTest.java` to verify the new functionality using `ReflectionTestUtils` for property injection.

---
*PR created automatically by Jules for task [6223580512272397389](https://jules.google.com/task/6223580512272397389) started by @lollito*