### PR TITLE
Secure GameService.delete with ownership check

### DIFF
--- a/src/main/java/com/lollito/fm/model/Game.java
+++ b/src/main/java/com/lollito/fm/model/Game.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -49,6 +50,11 @@ public class Game implements Serializable{
     
     @Column(name="crnt_date")
     private LocalDateTime currentDate;
+
+    @ManyToOne( fetch = FetchType.LAZY )
+    @JoinColumn( name = "owner_id" )
+    @ToString.Exclude
+    private User owner;
     
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
 	@JoinColumn( name = "game_id" )

--- a/src/main/java/com/lollito/fm/service/GameService.java
+++ b/src/main/java/com/lollito/fm/service/GameService.java
@@ -8,9 +8,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.lollito.fm.model.AdminRole;
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Country;
 import com.lollito.fm.model.Game;
+import com.lollito.fm.model.User;
 import com.lollito.fm.model.League;
 import com.lollito.fm.model.Match;
 import com.lollito.fm.model.MatchStatus;
@@ -18,6 +20,7 @@ import com.lollito.fm.model.Player;
 import com.lollito.fm.model.rest.GameResponse;
 import com.lollito.fm.repository.rest.GameRepository;
 import com.lollito.fm.repository.rest.MatchRepository;
+import org.springframework.security.access.AccessDeniedException;
 
 @Service
 public class GameService {
@@ -32,10 +35,12 @@ public class GameService {
 	@Autowired private SimulationMatchService simulationMatchService;
 	@Autowired private CountryService countryService;
 	@Autowired private PlayerService playerService;
+	@Autowired private UserService userService;
 	
 	public Game create(String gameName){
 		Game game = new Game();
 		game.setName(gameName);
+		game.setOwner(userService.getLoggedUser());
 //		LocalDate gameStartDate = LocalDate.of(2020, Month.AUGUST, 21);
 		LocalDateTime gameStartDate = LocalDateTime.now();
 		for(Country country : countryService.findByCreateLeague(true)){
@@ -127,7 +132,15 @@ public class GameService {
 	}
 	
 	public void delete(Long gameId){
-		//TODO security
+		User user = userService.getLoggedUser();
+		Game game = gameRepository.findById(gameId).orElseThrow(() -> new RuntimeException("Game not found"));
+
+		boolean isOwner = user.equals(game.getOwner());
+		boolean isAdmin = user.getAdminRole() == AdminRole.SUPER_ADMIN;
+
+		if (!isOwner && !isAdmin) {
+			throw new AccessDeniedException("Access denied");
+		}
 		gameRepository.deleteById(gameId);
 	}
 }

--- a/src/test/java/com/lollito/fm/service/GameServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/GameServiceTest.java
@@ -1,0 +1,90 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.lollito.fm.model.AdminRole;
+import com.lollito.fm.model.Game;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.rest.GameRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GameServiceTest {
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private GameService gameService;
+
+    @Test
+    void delete_whenUserIsSuperAdmin_shouldDeleteGame() {
+        Long gameId = 1L;
+        User admin = new User();
+        admin.setAdminRole(AdminRole.SUPER_ADMIN);
+
+        Game game = new Game();
+        game.setId(gameId);
+
+        when(userService.getLoggedUser()).thenReturn(admin);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.delete(gameId);
+
+        verify(gameRepository).deleteById(gameId);
+    }
+
+    @Test
+    void delete_whenUserIsOwner_shouldDeleteGame() {
+        Long gameId = 1L;
+        User owner = new User();
+        owner.setId(100L);
+        owner.setUsername("owner");
+
+        Game game = new Game();
+        game.setId(gameId);
+        game.setOwner(owner);
+
+        when(userService.getLoggedUser()).thenReturn(owner);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.delete(gameId);
+
+        verify(gameRepository).deleteById(gameId);
+    }
+
+    @Test
+    void delete_whenUserIsNeitherOwnerNorAdmin_shouldThrowAccessDeniedException() {
+        Long gameId = 1L;
+        User otherUser = new User();
+        otherUser.setId(200L);
+        otherUser.setUsername("other");
+
+        User owner = new User();
+        owner.setId(100L);
+        owner.setUsername("owner");
+
+        Game game = new Game();
+        game.setId(gameId);
+        game.setOwner(owner);
+
+        when(userService.getLoggedUser()).thenReturn(otherUser);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        assertThrows(AccessDeniedException.class, () -> gameService.delete(gameId));
+
+        verify(gameRepository, never()).deleteById(anyLong());
+    }
+}


### PR DESCRIPTION
Secured the `GameService.delete` method to prevent unauthorized game deletion. Added an ownership model where the creator of the game (via `create`) is assigned as the owner. The `delete` method now enforces that only the owner or a `SUPER_ADMIN` can delete a game. This addresses the issue where any user could potentially delete any game.

---
*PR created automatically by Jules for task [10764228274687076005](https://jules.google.com/task/10764228274687076005) started by @lollito*