### PR TITLE
⚡ Optimize GameService to avoid inefficient full graph save

### DIFF
--- a/src/main/java/com/lollito/fm/service/GameService.java
+++ b/src/main/java/com/lollito/fm/service/GameService.java
@@ -18,6 +18,7 @@ import com.lollito.fm.model.Player;
 import com.lollito.fm.model.rest.GameResponse;
 import com.lollito.fm.repository.rest.GameRepository;
 import com.lollito.fm.repository.rest.MatchRepository;
+import com.lollito.fm.repository.rest.SeasonRepository;
 
 @Service
 public class GameService {
@@ -26,6 +27,7 @@ public class GameService {
 	
 	@Autowired private GameRepository gameRepository;
 	@Autowired private MatchRepository matchRepository;
+	@Autowired private SeasonRepository seasonRepository;
 	@Autowired private SeasonService seasonService;
 	@Autowired private ClubService clubService;
 	@Autowired private LeagueService leagueService;
@@ -62,8 +64,14 @@ public class GameService {
 		GameResponse gameResponse = new GameResponse();
 		List<Match> matches = matchRepository.findByRoundSeasonAndDateBeforeAndFinish(league.getCurrentSeason(), LocalDateTime.now(), Boolean.FALSE);
 		if(matches.isEmpty()){
-			incrementPlayersCondition(league);
-			updatePlayerSkills(league);
+			for(Club club : league.getClubs()) {
+				for(Player player : club.getTeam().getPlayers()) {
+					double increment = -((10 * player.getStamina())/99) + (1000/99);
+					player.incrementCondition(increment);
+				}
+				playerService.updateSkills(club.getTeam().getPlayers());
+				playerService.saveAll(club.getTeam().getPlayers());
+			}
 		} else {
 			for (Match match : matches) {
 				if (match.getStatus() == MatchStatus.SCHEDULED) {
@@ -73,31 +81,17 @@ public class GameService {
 			Match match =  matches.get(matches.size() -1);
 			if(match.getLast()) {
 				league.getCurrentSeason().setNextRoundNumber(match.getRound().getNumber() + 1);
+				seasonRepository.save(league.getCurrentSeason());
 				if(match.getRound().getLast()){
 					league.addSeasonHistory(league.getCurrentSeason());
 					league.setCurrentSeason(seasonService.create(league, LocalDateTime.now().plusMinutes(10)));
+					leagueService.save(league);
 				}
 			} 
 		}
 		gameResponse.setDisputatedMatch(matches);
 		
-		leagueService.save(league);
 		return gameResponse;
-	}
-
-	private void updatePlayerSkills(League league) {
-		for(Club club : league.getClubs()) {
-			playerService.updateSkills(club.getTeam().getPlayers());
-		}
-	}
-	
-	private void incrementPlayersCondition(League league) {
-		for(Club club : league.getClubs()) {
-			for(Player player : club.getTeam().getPlayers()) {
-				double increment = -((10 * player.getStamina())/99) + (1000/99);
-	        	player.incrementCondition(increment);
-			}
-		}
 	}
 	
 	public GameResponse load(){


### PR DESCRIPTION
Optimized `GameService.next(League league)` to replace the inefficient full graph save of the League entity with granular saves of modified entities (Season, Players). This prevents performance degradation as the game history grows.

Key changes:
- Removed `leagueService.save(league)` from the main loop.
- Added explicit `seasonRepository.save` for round updates.
- Added explicit `playerService.saveAll` for player condition/skill updates.
- Retained `leagueService.save` only for season transition events.
- Refactored player update logic to avoid double iteration.

---
*PR created automatically by Jules for task [3514972948420750997](https://jules.google.com/task/3514972948420750997) started by @lollito*