### PR TITLE
Fix infinite recursion in JSON serialization for Sponsorship entities

### DIFF
--- a/src/main/java/com/lollito/fm/model/Sponsor.java
+++ b/src/main/java/com/lollito/fm/model/Sponsor.java
@@ -29,6 +29,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 @Table(name = "sponsor")
 @Getter
@@ -75,11 +77,13 @@ public class Sponsor implements Serializable {
     @OneToMany(mappedBy = "sponsor", cascade = CascadeType.ALL)
     @Builder.Default
     @ToString.Exclude
+    @JsonIgnore
     private List<SponsorshipDeal> deals = new ArrayList<>();
 
     @OneToMany(mappedBy = "sponsor", cascade = CascadeType.ALL)
     @Builder.Default
     @ToString.Exclude
+    @JsonIgnore
     private List<SponsorshipOffer> offers = new ArrayList<>();
     
     private Boolean isActive;

--- a/src/main/java/com/lollito/fm/model/SponsorshipBonus.java
+++ b/src/main/java/com/lollito/fm/model/SponsorshipBonus.java
@@ -25,6 +25,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 @Table(name = "sponsorship_bonus")
 @Getter
@@ -48,6 +50,7 @@ public class SponsorshipBonus implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sponsorship_deal_id")
     @ToString.Exclude
+    @JsonIgnore
     private SponsorshipDeal sponsorshipDeal;
 
     @Enumerated(EnumType.STRING)
@@ -61,6 +64,7 @@ public class SponsorshipBonus implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "season_id")
     @ToString.Exclude
+    @JsonIgnore
     private Season season;
 
     private String notes;

--- a/src/main/java/com/lollito/fm/model/SponsorshipPayment.java
+++ b/src/main/java/com/lollito/fm/model/SponsorshipPayment.java
@@ -25,6 +25,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 @Table(name = "sponsorship_payment")
 @Getter
@@ -48,6 +50,7 @@ public class SponsorshipPayment implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sponsorship_deal_id")
     @ToString.Exclude
+    @JsonIgnore
     private SponsorshipDeal sponsorshipDeal;
 
     @Enumerated(EnumType.STRING)
@@ -66,5 +69,6 @@ public class SponsorshipPayment implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "season_id")
     @ToString.Exclude
+    @JsonIgnore
     private Season season;
 }


### PR DESCRIPTION
Resolved `HttpMessageNotWritableException` caused by infinite recursion in JSON serialization.
The recursion occurred in chains involving `Club` -> `Finance` -> `Sponsorship` -> `Sponsor` -> `deals` (SponsorshipDeal) -> `Club`, and similar loops in `SponsorshipPayment` and `SponsorshipBonus`.

Changes:
- `Sponsor.java`: Added `@JsonIgnore` to `deals` and `offers`.
- `SponsorshipPayment.java`: Added `@JsonIgnore` to `sponsorshipDeal` and `season`.
- `SponsorshipBonus.java`: Added `@JsonIgnore` to `sponsorshipDeal` and `season`.

---
*PR created automatically by Jules for task [10476826895471479496](https://jules.google.com/task/10476826895471479496) started by @lollito*