### PR TITLE
Integrate MapStruct and Refactor Controllers to use DTOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,10 +156,38 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-processor</artifactId>
+			<version>1.5.5.Final</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/lollito/fm/controller/rest/ClubController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/ClubController.java
@@ -9,9 +9,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lollito.fm.model.Club;
+import com.lollito.fm.model.dto.ClubDTO;
 import com.lollito.fm.repository.rest.CountryRepository;
 import com.lollito.fm.service.ClubService;
 import com.lollito.fm.service.UserService;
+import com.lollito.fm.mapper.ClubMapper;
 
 @RestController
 @RequestMapping(value="/api/club")
@@ -22,10 +24,11 @@ public class ClubController {
 	@Autowired private ClubService clubService;
 	@Autowired private UserService userService;
 	@Autowired private CountryRepository countryRepository;
+	@Autowired private ClubMapper clubMapper;
 	
 	@RequestMapping(value = "/", method = RequestMethod.GET)
-    public Club club() {
-        return userService.getLoggedUser().getClub();
+    public ClubDTO club() {
+        return clubMapper.toDto(userService.getLoggedUser().getClub());
     }
    
 	@RequestMapping(value = "/count", method = RequestMethod.GET)
@@ -34,12 +37,12 @@ public class ClubController {
     }
 	
 	@RequestMapping(value = "/findTopByLeagueCountry/{countryId}", method = RequestMethod.GET)
-    public Club findTopByLeagueCountry(@PathVariable (value = "countryId") Long countryId) {
-        return clubService.findTopByLeagueCountry(countryRepository.findById(countryId).get());
+    public ClubDTO findTopByLeagueCountry(@PathVariable (value = "countryId") Long countryId) {
+        return clubMapper.toDto(clubService.findTopByLeagueCountry(countryRepository.findById(countryId).get()));
     }
 	
 	@RequestMapping(value = "/findTopByLeagueCountryAndUserIsNull/{countryId}", method = RequestMethod.GET)
-    public Club findTopByLeagueCountryAndUserIsNull(@PathVariable (value = "countryId") Long countryId) {
-        return clubService.findTopByLeagueCountryAndUserIsNull(countryRepository.findById(countryId).get());
+    public ClubDTO findTopByLeagueCountryAndUserIsNull(@PathVariable (value = "countryId") Long countryId) {
+        return clubMapper.toDto(clubService.findTopByLeagueCountryAndUserIsNull(countryRepository.findById(countryId).get()));
     }
 }

--- a/src/main/java/com/lollito/fm/controller/rest/GameController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/GameController.java
@@ -11,8 +11,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lollito.fm.model.Game;
+import com.lollito.fm.model.dto.GameDTO;
 import com.lollito.fm.model.rest.GameResponse;
 import com.lollito.fm.service.GameService;
+import com.lollito.fm.mapper.GameMapper;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value="/api/game")
@@ -21,6 +24,7 @@ public class GameController {
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 	
 	@Autowired private GameService gameService;
+	@Autowired private GameMapper gameMapper;
 	
 	@RequestMapping(value = "/", method = RequestMethod.POST)
     public GameResponse create(@RequestParam(required = true) String gameName) {
@@ -34,8 +38,10 @@ public class GameController {
     }
 	
 	@RequestMapping(value = "/findAll", method = RequestMethod.GET)
-    public List<Game> findAll() {
-		return gameService.findAll();
+    public List<GameDTO> findAll() {
+		return gameService.findAll().stream()
+			.map(gameMapper::toDto)
+			.collect(Collectors.toList());
     }
 	
 	@RequestMapping(value = "/next", method = RequestMethod.POST)

--- a/src/main/java/com/lollito/fm/controller/rest/PlayerController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/PlayerController.java
@@ -13,9 +13,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lollito.fm.model.Player;
+import com.lollito.fm.dto.PlayerDTO;
 import com.lollito.fm.model.rest.PlayerCondition;
 import com.lollito.fm.service.PlayerService;
 import com.lollito.fm.service.UserService;
+import com.lollito.fm.mapper.PlayerMapper;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value="/api/player")
@@ -25,10 +28,13 @@ public class PlayerController {
 	
 	@Autowired private UserService userService;
 	@Autowired private PlayerService playerService;
+	@Autowired private PlayerMapper playerMapper;
 	
 	@GetMapping(value = "/")
-    public List<Player> players() {
-        return userService.getLoggedUser().getClub().getTeam().getPlayers();
+    public List<PlayerDTO> players() {
+        return userService.getLoggedUser().getClub().getTeam().getPlayers().stream()
+			.map(playerMapper::toDto)
+			.collect(Collectors.toList());
     }
    
 	
@@ -38,17 +44,19 @@ public class PlayerController {
     }
 	
 	@GetMapping(value = "/onSale")
-	public List<Player> getOnSale() {
-		return playerService.findByOnSale(Boolean.TRUE);
+	public List<PlayerDTO> getOnSale() {
+		return playerService.findByOnSale(Boolean.TRUE).stream()
+			.map(playerMapper::toDto)
+			.collect(Collectors.toList());
 	}
 	
 	@PostMapping(value = "/{id}/onSale")
-	public Player onSale(@PathVariable(value="id") Long id) {
-		return playerService.onSale(id);
+	public PlayerDTO onSale(@PathVariable(value="id") Long id) {
+		return playerMapper.toDto(playerService.onSale(id));
 	}
 
 	@PostMapping(value = "/{id}/change-role")
-	public Player changeRole(@PathVariable(value="id") Long id, @RequestParam(value="role") Integer role) {
-		return playerService.changeRole(id, role);
+	public PlayerDTO changeRole(@PathVariable(value="id") Long id, @RequestParam(value="role") Integer role) {
+		return playerMapper.toDto(playerService.changeRole(id, role));
 	}
 }

--- a/src/main/java/com/lollito/fm/controller/rest/StaffController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/StaffController.java
@@ -26,6 +26,7 @@ import com.lollito.fm.model.Staff;
 import com.lollito.fm.model.StaffContract;
 import com.lollito.fm.model.StaffRole;
 import com.lollito.fm.service.StaffService;
+import com.lollito.fm.mapper.StaffMapper;
 
 @RestController
 @RequestMapping("/api/staff")
@@ -34,11 +35,14 @@ public class StaffController {
     @Autowired
     private StaffService staffService;
 
+    @Autowired
+    private StaffMapper staffMapper;
+
     @GetMapping("/club/{clubId}")
     public ResponseEntity<List<StaffDTO>> getClubStaff(@PathVariable Long clubId) {
         List<Staff> staff = staffService.getClubStaff(clubId);
         return ResponseEntity.ok(staff.stream()
-            .map(this::convertToDTO)
+            .map(staffMapper::toDto)
             .collect(Collectors.toList()));
     }
 
@@ -49,7 +53,7 @@ public class StaffController {
             @RequestParam(defaultValue = "20") int size) {
         Page<Staff> staff = staffService.getAvailableStaff(role, PageRequest.of(page, size));
         return ResponseEntity.ok(staff.getContent().stream()
-            .map(this::convertToDTO)
+            .map(staffMapper::toDto)
             .collect(Collectors.toList()));
     }
 
@@ -60,7 +64,7 @@ public class StaffController {
             request.getStaffId(),
             request
         );
-        return ResponseEntity.ok(convertToContractDTO(contract));
+        return ResponseEntity.ok(staffMapper.toDto(contract));
     }
 
     @PostMapping("/{staffId}/fire")
@@ -76,7 +80,7 @@ public class StaffController {
             @PathVariable Long staffId,
             @RequestBody RenewContractRequest request) {
         StaffContract contract = staffService.renewContract(staffId, request);
-        return ResponseEntity.ok(convertToContractDTO(contract));
+        return ResponseEntity.ok(staffMapper.toDto(contract));
     }
 
     @GetMapping("/club/{clubId}/bonuses")
@@ -92,50 +96,7 @@ public class StaffController {
             @RequestParam(defaultValue = "10") int count) {
         List<Staff> staff = staffService.generateAvailableStaff(role, count);
         return ResponseEntity.ok(staff.stream()
-            .map(this::convertToDTO)
+            .map(staffMapper::toDto)
             .collect(Collectors.toList()));
-    }
-
-    private StaffDTO convertToDTO(Staff staff) {
-        StaffDTO dto = new StaffDTO();
-        dto.setId(staff.getId());
-        dto.setName(staff.getName());
-        dto.setSurname(staff.getSurname());
-        dto.setBirth(staff.getBirth());
-        dto.setAge(staff.getAge());
-        dto.setClubId(staff.getClub() != null ? staff.getClub().getId() : null);
-        dto.setRole(staff.getRole());
-        dto.setSpecialization(staff.getSpecialization());
-        dto.setAbility(staff.getAbility());
-        dto.setReputation(staff.getReputation());
-        dto.setMonthlySalary(staff.getMonthlySalary());
-        dto.setContractStart(staff.getContractStart());
-        dto.setContractEnd(staff.getContractEnd());
-        dto.setStatus(staff.getStatus());
-        dto.setMotivationBonus(staff.getMotivationBonus());
-        dto.setTrainingBonus(staff.getTrainingBonus());
-        dto.setInjuryPreventionBonus(staff.getInjuryPreventionBonus());
-        dto.setRecoveryBonus(staff.getRecoveryBonus());
-        dto.setScoutingBonus(staff.getScoutingBonus());
-        dto.setNationalityName(staff.getNationality() != null ? staff.getNationality().getName() : null);
-        dto.setDescription(staff.getDescription());
-        dto.setExperience(staff.getExperience());
-        return dto;
-    }
-
-    private StaffContractDTO convertToContractDTO(StaffContract contract) {
-        StaffContractDTO dto = new StaffContractDTO();
-        dto.setId(contract.getId());
-        dto.setStaffId(contract.getStaff().getId());
-        dto.setClubId(contract.getClub().getId());
-        dto.setMonthlySalary(contract.getMonthlySalary());
-        dto.setSigningBonus(contract.getSigningBonus());
-        dto.setPerformanceBonus(contract.getPerformanceBonus());
-        dto.setStartDate(contract.getStartDate());
-        dto.setEndDate(contract.getEndDate());
-        dto.setStatus(contract.getStatus());
-        dto.setTerminationClause(contract.getTerminationClause());
-        dto.setTerminationFee(contract.getTerminationFee());
-        return dto;
     }
 }

--- a/src/main/java/com/lollito/fm/controller/rest/UserController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/UserController.java
@@ -21,9 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.lollito.fm.config.security.jwt.JwtUtils;
 import com.lollito.fm.model.User;
+import com.lollito.fm.model.dto.UserDTO;
 import com.lollito.fm.model.rest.JwtResponse;
 import com.lollito.fm.model.rest.RegistrationRequest;
 import com.lollito.fm.service.UserService;
+import com.lollito.fm.mapper.UserMapper;
 
 @RestController
 @RequestMapping(value="/api/user")
@@ -36,6 +38,8 @@ public class UserController {
 	@Autowired private AuthenticationManager authenticationManager;
 
 	@Autowired private JwtUtils jwtUtils;
+
+	@Autowired private UserMapper userMapper;
 	
 	@RequestMapping(value = "/count", method = RequestMethod.GET)
     public Long count() {
@@ -91,6 +95,10 @@ public class UserController {
     
     @GetMapping("/")
 	public ResponseEntity<?> findAll (  ) {
-		return ResponseEntity.ok( userService.findAll() );
+		return ResponseEntity.ok(
+            java.util.stream.StreamSupport.stream(userService.findAll().spliterator(), false)
+                .map(userMapper::toDto)
+                .collect(Collectors.toList())
+        );
 	}
 }

--- a/src/main/java/com/lollito/fm/mapper/ClubMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/ClubMapper.java
@@ -1,0 +1,14 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.dto.ClubDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ClubMapper {
+    @Mapping(source = "league.id", target = "leagueId")
+    @Mapping(source = "team.id", target = "teamId")
+    ClubDTO toDto(Club club);
+    Club toEntity(ClubDTO dto);
+}

--- a/src/main/java/com/lollito/fm/mapper/GameMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/GameMapper.java
@@ -1,0 +1,11 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Game;
+import com.lollito.fm.model.dto.GameDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameMapper {
+    GameDTO toDto(Game game);
+    Game toEntity(GameDTO dto);
+}

--- a/src/main/java/com/lollito/fm/mapper/LeagueMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/LeagueMapper.java
@@ -1,0 +1,11 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.dto.LeagueDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface LeagueMapper {
+    LeagueDTO toDto(League league);
+    League toEntity(LeagueDTO dto);
+}

--- a/src/main/java/com/lollito/fm/mapper/PlayerMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/PlayerMapper.java
@@ -1,0 +1,11 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Player;
+import com.lollito.fm.dto.PlayerDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PlayerMapper {
+    PlayerDTO toDto(Player player);
+    Player toEntity(PlayerDTO dto);
+}

--- a/src/main/java/com/lollito/fm/mapper/ScoutingMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/ScoutingMapper.java
@@ -1,0 +1,35 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Scout;
+import com.lollito.fm.model.ScoutingAssignment;
+import com.lollito.fm.model.ScoutingReport;
+import com.lollito.fm.model.PlayerScoutingStatus;
+import com.lollito.fm.dto.ScoutDTO;
+import com.lollito.fm.dto.ScoutingAssignmentDTO;
+import com.lollito.fm.dto.ScoutingReportDTO;
+import com.lollito.fm.dto.PlayerScoutingStatusDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ScoutingMapper {
+    @Mapping(source = "club.id", target = "clubId")
+    @Mapping(source = "scoutingRegion.id", target = "regionId")
+    @Mapping(source = "scoutingRegion.name", target = "regionName")
+    ScoutDTO toDto(Scout scout);
+
+    @Mapping(source = "targetPlayer.id", target = "targetPlayerId")
+    @Mapping(source = "targetPlayer.name", target = "targetPlayerName")
+    @Mapping(source = "targetPlayer.surname", target = "targetPlayerSurname")
+    ScoutingAssignmentDTO toDto(ScoutingAssignment assignment);
+
+    @Mapping(source = "assignment.id", target = "assignmentId")
+    @Mapping(source = "player.id", target = "playerId")
+    @Mapping(source = "player.name", target = "playerName")
+    @Mapping(source = "player.surname", target = "playerSurname")
+    ScoutingReportDTO toDto(ScoutingReport report);
+
+    @Mapping(source = "player.id", target = "playerId")
+    @Mapping(source = "scoutingClub.id", target = "clubId")
+    PlayerScoutingStatusDTO toDto(PlayerScoutingStatus status);
+}

--- a/src/main/java/com/lollito/fm/mapper/StaffMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/StaffMapper.java
@@ -1,0 +1,19 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Staff;
+import com.lollito.fm.model.StaffContract;
+import com.lollito.fm.dto.StaffDTO;
+import com.lollito.fm.dto.StaffContractDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface StaffMapper {
+    @Mapping(source = "club.id", target = "clubId")
+    @Mapping(source = "nationality.name", target = "nationalityName")
+    StaffDTO toDto(Staff staff);
+
+    @Mapping(source = "staff.id", target = "staffId")
+    @Mapping(source = "club.id", target = "clubId")
+    StaffContractDTO toDto(StaffContract contract);
+}

--- a/src/main/java/com/lollito/fm/mapper/TeamMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/TeamMapper.java
@@ -1,0 +1,11 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Team;
+import com.lollito.fm.model.dto.TeamDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TeamMapper {
+    TeamDTO toDto(Team team);
+    Team toEntity(TeamDTO dto);
+}

--- a/src/main/java/com/lollito/fm/mapper/TrainingMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/TrainingMapper.java
@@ -1,0 +1,25 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.TrainingPlan;
+import com.lollito.fm.model.TrainingSession;
+import com.lollito.fm.model.PlayerTrainingResult;
+import com.lollito.fm.model.dto.TrainingPlanDTO;
+import com.lollito.fm.model.dto.TrainingSessionDTO;
+import com.lollito.fm.model.dto.PlayerTrainingResultDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TrainingMapper {
+    @Mapping(source = "team.id", target = "teamId")
+    TrainingPlanDTO toDto(TrainingPlan plan);
+
+    @Mapping(source = "team.id", target = "teamId")
+    TrainingSessionDTO toDto(TrainingSession session);
+
+    @Mapping(source = "trainingSession.id", target = "trainingSessionId")
+    PlayerTrainingResultDTO toDto(PlayerTrainingResult result);
+
+    PlayerTrainingResultDTO.PlayerSummaryDTO toPlayerSummaryDto(Player player);
+}

--- a/src/main/java/com/lollito/fm/mapper/UserMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/UserMapper.java
@@ -1,0 +1,16 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.dto.UserDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    @Mapping(source = "country.name", target = "country")
+    UserDTO toDto(User user);
+
+    @Mapping(target = "country", ignore = true)
+    @Mapping(source = "country", target = "countryString")
+    User toEntity(UserDTO dto);
+}

--- a/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
@@ -1,0 +1,21 @@
+package com.lollito.fm.model.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClubDTO {
+    private Long id;
+    private String name;
+    private LocalDate foundation;
+    private String city;
+    private String logoURL;
+    private Long leagueId;
+    private Long teamId;
+}

--- a/src/main/java/com/lollito/fm/model/dto/GameDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/GameDTO.java
@@ -1,0 +1,17 @@
+package com.lollito.fm.model.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameDTO {
+    private Long id;
+    private String name;
+    private LocalDateTime currentDate;
+}

--- a/src/main/java/com/lollito/fm/model/dto/LeagueDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/LeagueDTO.java
@@ -1,0 +1,15 @@
+package com.lollito.fm.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeagueDTO {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/lollito/fm/model/dto/TeamDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/TeamDTO.java
@@ -1,0 +1,14 @@
+package com.lollito.fm.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamDTO {
+    private Long id;
+}

--- a/src/main/java/com/lollito/fm/rest/ScoutingController.java
+++ b/src/main/java/com/lollito/fm/rest/ScoutingController.java
@@ -30,6 +30,7 @@ import com.lollito.fm.model.Scout;
 import com.lollito.fm.model.ScoutingAssignment;
 import com.lollito.fm.model.ScoutingReport;
 import com.lollito.fm.service.ScoutingService;
+import com.lollito.fm.mapper.ScoutingMapper;
 
 @RestController
 @RequestMapping("/api/scouting")
@@ -38,11 +39,14 @@ public class ScoutingController {
     @Autowired
     private ScoutingService scoutingService;
 
+    @Autowired
+    private ScoutingMapper scoutingMapper;
+
     @GetMapping("/club/{clubId}/scouts")
     public ResponseEntity<List<ScoutDTO>> getClubScouts(@PathVariable Long clubId) {
         List<Scout> scouts = scoutingService.getClubScouts(clubId);
         return ResponseEntity.ok(scouts.stream()
-            .map(this::convertToDTO)
+            .map(scoutingMapper::toDto)
             .collect(Collectors.toList()));
     }
 
@@ -55,7 +59,7 @@ public class ScoutingController {
             request.getPriority(),
             request.getInstructions()
         );
-        return ResponseEntity.ok(convertToDTO(assignment));
+        return ResponseEntity.ok(scoutingMapper.toDto(assignment));
     }
 
     @GetMapping("/club/{clubId}/assignments")
@@ -64,7 +68,7 @@ public class ScoutingController {
             @RequestParam(required = false) AssignmentStatus status) {
         List<ScoutingAssignment> assignments = scoutingService.getClubAssignments(clubId, status);
         return ResponseEntity.ok(assignments.stream()
-            .map(this::convertToDTO)
+            .map(scoutingMapper::toDto)
             .collect(Collectors.toList()));
     }
 
@@ -73,7 +77,7 @@ public class ScoutingController {
             @PathVariable Long playerId,
             @PathVariable Long clubId) {
         PlayerScoutingStatus status = scoutingService.getPlayerScoutingStatus(playerId, clubId);
-        return ResponseEntity.ok(convertToDTO(status));
+        return ResponseEntity.ok(scoutingMapper.toDto(status));
     }
 
     @GetMapping("/player/{playerId}/revealed/{clubId}")
@@ -92,7 +96,7 @@ public class ScoutingController {
             @RequestParam(required = false) RecommendationLevel recommendation) {
         Page<ScoutingReport> reports = scoutingService.getScoutingReports(
             clubId, PageRequest.of(page, size), recommendation);
-        return ResponseEntity.ok(reports.map(this::convertToDTO));
+        return ResponseEntity.ok(reports.map(scoutingMapper::toDto));
     }
 
     @GetMapping("/club/{clubId}/recommendations")
@@ -115,103 +119,5 @@ public class ScoutingController {
     public ResponseEntity<Void> cancelAssignment(@PathVariable Long assignmentId) {
         scoutingService.cancelAssignment(assignmentId);
         return ResponseEntity.ok().build();
-    }
-
-    // Mappers
-
-    private ScoutDTO convertToDTO(Scout scout) {
-        ScoutDTO dto = new ScoutDTO();
-        dto.setId(scout.getId());
-        dto.setName(scout.getName());
-        dto.setSurname(scout.getSurname());
-        if(scout.getClub() != null) dto.setClubId(scout.getClub().getId());
-        if(scout.getScoutingRegion() != null) {
-            dto.setRegionId(scout.getScoutingRegion().getId());
-            dto.setRegionName(scout.getScoutingRegion().getName());
-        }
-        dto.setAbility(scout.getAbility());
-        dto.setReputation(scout.getReputation());
-        dto.setMonthlySalary(scout.getMonthlySalary());
-        dto.setSpecialization(scout.getSpecialization());
-        dto.setStatus(scout.getStatus());
-        dto.setContractEnd(scout.getContractEnd());
-        dto.setExperience(scout.getExperience());
-        return dto;
-    }
-
-    private ScoutingAssignmentDTO convertToDTO(ScoutingAssignment assignment) {
-        ScoutingAssignmentDTO dto = new ScoutingAssignmentDTO();
-        dto.setId(assignment.getId());
-        dto.setScout(convertToDTO(assignment.getScout()));
-        if(assignment.getTargetPlayer() != null) {
-            dto.setTargetPlayerId(assignment.getTargetPlayer().getId());
-            dto.setTargetPlayerName(assignment.getTargetPlayer().getName());
-            dto.setTargetPlayerSurname(assignment.getTargetPlayer().getSurname());
-        }
-        dto.setType(assignment.getType());
-        dto.setStatus(assignment.getStatus());
-        dto.setAssignedDate(assignment.getAssignedDate());
-        dto.setCompletionDate(assignment.getCompletionDate());
-        dto.setExpectedCompletionDate(assignment.getExpectedCompletionDate());
-        dto.setPriority(assignment.getPriority());
-        dto.setInstructions(assignment.getInstructions());
-        return dto;
-    }
-
-    private ScoutingReportDTO convertToDTO(ScoutingReport report) {
-        ScoutingReportDTO dto = new ScoutingReportDTO();
-        dto.setId(report.getId());
-        if(report.getAssignment() != null) dto.setAssignmentId(report.getAssignment().getId());
-        if(report.getPlayer() != null) {
-            dto.setPlayerId(report.getPlayer().getId());
-            dto.setPlayerName(report.getPlayer().getName());
-            dto.setPlayerSurname(report.getPlayer().getSurname());
-        }
-        if(report.getScout() != null) dto.setScout(convertToDTO(report.getScout()));
-        dto.setReportDate(report.getReportDate());
-        dto.setRevealedStamina(report.getRevealedStamina());
-        dto.setRevealedPlaymaking(report.getRevealedPlaymaking());
-        dto.setRevealedScoring(report.getRevealedScoring());
-        dto.setRevealedWinger(report.getRevealedWinger());
-        dto.setRevealedGoalkeeping(report.getRevealedGoalkeeping());
-        dto.setRevealedPassing(report.getRevealedPassing());
-        dto.setRevealedDefending(report.getRevealedDefending());
-        dto.setRevealedSetPieces(report.getRevealedSetPieces());
-        dto.setOverallRating(report.getOverallRating());
-        dto.setPotentialRating(report.getPotentialRating());
-        dto.setAccuracyLevel(report.getAccuracyLevel());
-        dto.setRecommendation(report.getRecommendation());
-        dto.setStrengths(report.getStrengths());
-        dto.setWeaknesses(report.getWeaknesses());
-        dto.setPersonalityAssessment(report.getPersonalityAssessment());
-        dto.setInjuryHistory(report.getInjuryHistory());
-        dto.setEstimatedValue(report.getEstimatedValue());
-        dto.setEstimatedWage(report.getEstimatedWage());
-        dto.setIsAvailableForTransfer(report.getIsAvailableForTransfer());
-        dto.setContractExpiry(report.getContractExpiry());
-        dto.setAdditionalNotes(report.getAdditionalNotes());
-        dto.setConfidenceLevel(report.getConfidenceLevel());
-        return dto;
-    }
-
-    private PlayerScoutingStatusDTO convertToDTO(PlayerScoutingStatus status) {
-        PlayerScoutingStatusDTO dto = new PlayerScoutingStatusDTO();
-        dto.setId(status.getId());
-        if(status.getPlayer() != null) dto.setPlayerId(status.getPlayer().getId());
-        if(status.getScoutingClub() != null) dto.setClubId(status.getScoutingClub().getId());
-        dto.setScoutingLevel(status.getScoutingLevel());
-        dto.setLastScoutedDate(status.getLastScoutedDate());
-        dto.setFirstScoutedDate(status.getFirstScoutedDate());
-        dto.setTimesScoutedThisSeason(status.getTimesScoutedThisSeason());
-        dto.setKnowledgeAccuracy(status.getKnowledgeAccuracy());
-        dto.setKnownStamina(status.getKnownStamina());
-        dto.setKnownPlaymaking(status.getKnownPlaymaking());
-        dto.setKnownScoring(status.getKnownScoring());
-        dto.setKnownWinger(status.getKnownWinger());
-        dto.setKnownGoalkeeping(status.getKnownGoalkeeping());
-        dto.setKnownPassing(status.getKnownPassing());
-        dto.setKnownDefending(status.getKnownDefending());
-        dto.setKnownSetPieces(status.getKnownSetPieces());
-        return dto;
     }
 }


### PR DESCRIPTION
This PR introduces MapStruct for object mapping and ensures that Controllers return DTOs instead of Entities, satisfying the requirement to "passa sempre dai dto" and "elimina i metodi custom di convert".

Key changes:
1.  **Dependencies**: Added MapStruct and configured annotation processing with Lombok.
2.  **DTOs**: Created missing core DTOs.
3.  **Mappers**: Created comprehensive Mappers for core and sub-systems.
4.  **Refactoring**: Updated Controllers to inject Mappers and return DTOs. Removed manual `convertToDTO` private methods in sub-system controllers.
5.  **API Changes**: `findAll` methods now return Lists of DTOs. `Club` response is flatter.

Verified with `mvn clean compile` and `mvn test`.

---
*PR created automatically by Jules for task [3998592958492936261](https://jules.google.com/task/3998592958492936261) started by @lollito*