### PR TITLE
Separate Users and Admins

### DIFF
--- a/fm-admin/src/App.js
+++ b/fm-admin/src/App.js
@@ -10,8 +10,16 @@ import ClubManagement from './pages/ClubManagement';
 
 const PrivateRoute = ({ children }) => {
   const { user } = useContext(AuthContext);
-  // Ideally check for ADMIN role here
-  return user ? children : <Navigate to="/login" />;
+
+  if (!user) {
+    return <Navigate to="/login" />;
+  }
+
+  if (!user.roles || !user.roles.includes('ROLE_ADMIN')) {
+    return <Navigate to="/login" />;
+  }
+
+  return children;
 };
 
 function App() {

--- a/src/main/java/com/lollito/fm/DatabaseLoader.java
+++ b/src/main/java/com/lollito/fm/DatabaseLoader.java
@@ -11,10 +11,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import com.lollito.fm.model.AdminRole;
+import com.lollito.fm.model.Role;
 import com.lollito.fm.model.User;
 import com.lollito.fm.model.rest.RegistrationRequest;
+import com.lollito.fm.repository.rest.RoleRepository;
 import com.lollito.fm.repository.rest.UserRepository;
 import com.lollito.fm.service.CountryService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import com.lollito.fm.service.GameService;
 import com.lollito.fm.service.ModuleService;
 import com.lollito.fm.service.UserService;
@@ -29,10 +33,23 @@ public class DatabaseLoader implements CommandLineRunner {
 	@Autowired private CountryService countryService;
 	@Autowired private UserService userService;
 	@Autowired private UserRepository userRepository;
+	@Autowired private RoleRepository roleRepository;
+	@Autowired private BCryptPasswordEncoder bCryptPasswordEncoder;
 	
 	@Override
 	public void run(String... strings) throws Exception {
 		logger.info("Loading Database");
+
+		// Initialize Roles
+		Role roleUser = roleRepository.findByName("ROLE_USER");
+		if (roleUser == null) {
+			roleUser = roleRepository.save(Role.builder().name("ROLE_USER").build());
+		}
+
+		Role roleAdmin = roleRepository.findByName("ROLE_ADMIN");
+		if (roleAdmin == null) {
+			roleAdmin = roleRepository.save(Role.builder().name("ROLE_ADMIN").build());
+		}
 
 		// Setup System User for Game Creation
 		if (!userRepository.existsByUsername("system")) {
@@ -41,7 +58,37 @@ public class DatabaseLoader implements CommandLineRunner {
 			systemUser.setPassword("syspass");
 			systemUser.setEmail("sys@sys.com");
 			systemUser.setActive(true);
+			systemUser.setAdminRole(AdminRole.SUPER_ADMIN);
+			systemUser.getRoles().add(roleAdmin);
 			userRepository.save(systemUser);
+		} else {
+			User systemUser = userRepository.findByUsernameAndActive("system", true);
+			if (systemUser != null) {
+				boolean changed = false;
+				if (systemUser.getAdminRole() == null) {
+					systemUser.setAdminRole(AdminRole.SUPER_ADMIN);
+					changed = true;
+				}
+				if (!systemUser.getRoles().contains(roleAdmin)) {
+					systemUser.getRoles().add(roleAdmin);
+					changed = true;
+				}
+				if (changed) {
+					userRepository.save(systemUser);
+				}
+			}
+		}
+
+		// Setup Admin User
+		if (!userRepository.existsByUsername("admin")) {
+			User adminUser = new User();
+			adminUser.setUsername("admin");
+			adminUser.setPassword(bCryptPasswordEncoder.encode("admin"));
+			adminUser.setEmail("admin@admin.com");
+			adminUser.setActive(true);
+			adminUser.setAdminRole(AdminRole.SUPER_ADMIN);
+			adminUser.getRoles().add(roleAdmin);
+			userRepository.save(adminUser);
 		}
 
 		// Auth as system to create game (which creates clubs)

--- a/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
@@ -65,6 +65,7 @@ public class WebSecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
             );
 

--- a/src/main/java/com/lollito/fm/repository/rest/RoleRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/RoleRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.lollito.fm.model.Role;
 
 public interface RoleRepository extends JpaRepository<Role, Long>{
+    Role findByName(String name);
 }

--- a/src/main/java/com/lollito/fm/service/UserService.java
+++ b/src/main/java/com/lollito/fm/service/UserService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.News;
+import com.lollito.fm.model.Role;
 import com.lollito.fm.model.User;
 import com.lollito.fm.model.rest.RegistrationRequest;
 import com.lollito.fm.repository.rest.CountryRepository;
@@ -45,8 +46,11 @@ public class UserService {
         club.setName(request.getClubName());
         clubService.save(club);
 		user.setClub(club);
-        //TODO temp roles
-        user.setRoles(new HashSet<>(roleRepository.findAll()));
+
+        Role userRole = roleRepository.findByName("ROLE_USER");
+        if (userRole != null) {
+            user.getRoles().add(userRole);
+        }
         
         News news = new News(String.format("%s is the new manager of %s", user.getUsername(), user.getClub().getName()) , LocalDateTime.now());
         newsService.save(news);


### PR DESCRIPTION
Implemented role-based separation between game users and administrators. Regular users now receive ROLE_USER upon registration, while admin access is restricted to users with ROLE_ADMIN. The fm-admin frontend and backend admin endpoints are now protected.

---
*PR created automatically by Jules for task [15021918228919105716](https://jules.google.com/task/15021918228919105716) started by @lollito*