### PR TITLE
Feature: Youth Academy Candidate Generation

### DIFF
--- a/src/main/java/com/lollito/fm/controller/YouthAcademyController.java
+++ b/src/main/java/com/lollito/fm/controller/YouthAcademyController.java
@@ -1,0 +1,43 @@
+package com.lollito.fm.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lollito.fm.mapper.PlayerMapper;
+import com.lollito.fm.mapper.YouthCandidateMapper;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.dto.PlayerDTO;
+import com.lollito.fm.model.dto.YouthCandidateDTO;
+import com.lollito.fm.service.YouthAcademyService;
+
+@RestController
+@RequestMapping("/api/youth-academy")
+public class YouthAcademyController {
+
+    @Autowired private YouthAcademyService youthAcademyService;
+    @Autowired private YouthCandidateMapper youthCandidateMapper;
+    @Autowired private PlayerMapper playerMapper;
+
+    @GetMapping("/{id}/candidates")
+    public ResponseEntity<List<YouthCandidateDTO>> getCandidates(@PathVariable Long id) {
+        return ResponseEntity.ok(
+            youthAcademyService.getCandidates(id).stream()
+                .map(youthCandidateMapper::toDto)
+                .collect(Collectors.toList())
+        );
+    }
+
+    @PostMapping("/promote/{candidateId}")
+    public ResponseEntity<PlayerDTO> promoteCandidate(@PathVariable Long candidateId) {
+        Player player = youthAcademyService.promoteCandidate(candidateId);
+        return ResponseEntity.ok(playerMapper.toDto(player));
+    }
+}

--- a/src/main/java/com/lollito/fm/mapper/YouthCandidateMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/YouthCandidateMapper.java
@@ -1,0 +1,12 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.YouthCandidate;
+import com.lollito.fm.model.dto.YouthCandidateDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface YouthCandidateMapper {
+    @Mapping(target = "nationality", expression = "java(entity.getNationality() != null ? entity.getNationality().getName() : null)")
+    YouthCandidateDTO toDto(YouthCandidate entity);
+}

--- a/src/main/java/com/lollito/fm/model/YouthAcademy.java
+++ b/src/main/java/com/lollito/fm/model/YouthAcademy.java
@@ -3,11 +3,15 @@ package com.lollito.fm.model;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -47,6 +51,12 @@ public class YouthAcademy implements Serializable {
     @JsonIgnore
     @ToString.Exclude
     private Club club;
+
+    @OneToMany(mappedBy = "youthAcademy", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    @ToString.Exclude
+    @JsonIgnore
+    private List<YouthCandidate> candidates = new ArrayList<>();
 
     private String name;
 

--- a/src/main/java/com/lollito/fm/model/YouthCandidate.java
+++ b/src/main/java/com/lollito/fm/model/YouthCandidate.java
@@ -1,0 +1,100 @@
+package com.lollito.fm.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.Period;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.GenericGenerator;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Entity
+@Table(name = "youth_candidate")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString
+public class YouthCandidate implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    private String name;
+    private String surname;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+    private LocalDate birth;
+
+    @Enumerated(EnumType.ORDINAL)
+    private PlayerRole role;
+
+    @Enumerated(EnumType.ORDINAL)
+    private Foot preferredFoot;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "nationality_id")
+    @ToString.Exclude
+    private Country nationality;
+
+    // Attributes (Current ability of the candidate)
+    private Double stamina;
+    private Double playmaking;
+    private Double scoring;
+    private Double winger;
+    private Double goalkeeping;
+    private Double passing;
+    private Double defending;
+    private Double setPieces;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "youth_academy_id")
+    @JsonIgnore
+    @ToString.Exclude
+    private YouthAcademy youthAcademy;
+
+    @Transient
+    public Integer getAge() {
+        return Period.between(birth, LocalDate.now()).getYears();
+    }
+
+    @Transient
+    public Integer getAverage(){
+        return ((this.stamina == null ? 0 : this.stamina.intValue()) +
+                (this.playmaking == null ? 0 : this.playmaking.intValue()) +
+                (this.scoring == null ? 0 : this.scoring.intValue()) +
+                (this.winger == null ? 0 : this.winger.intValue()) +
+                (this.goalkeeping == null ? 0 : this.goalkeeping.intValue()) +
+                (this.passing == null ? 0 : this.passing.intValue()) +
+                (this.defending == null ? 0 : this.defending.intValue()) +
+                (this.setPieces == null ? 0 : this.setPieces.intValue())) / 8;
+    }
+}

--- a/src/main/java/com/lollito/fm/model/dto/YouthCandidateDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/YouthCandidateDTO.java
@@ -1,0 +1,39 @@
+package com.lollito.fm.model.dto;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import com.lollito.fm.model.Foot;
+import com.lollito.fm.model.PlayerRole;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class YouthCandidateDTO implements Serializable {
+    private Long id;
+    private String name;
+    private String surname;
+    private Integer age;
+    private PlayerRole role;
+    private Foot preferredFoot;
+    private String nationality;
+
+    // Attributes
+    private Double stamina;
+    private Double playmaking;
+    private Double scoring;
+    private Double winger;
+    private Double goalkeeping;
+    private Double passing;
+    private Double defending;
+    private Double setPieces;
+
+    private Integer average;
+}

--- a/src/main/java/com/lollito/fm/repository/rest/YouthCandidateRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/YouthCandidateRepository.java
@@ -1,0 +1,13 @@
+package com.lollito.fm.repository.rest;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.lollito.fm.model.YouthCandidate;
+
+@Repository
+public interface YouthCandidateRepository extends JpaRepository<YouthCandidate, Long> {
+    List<YouthCandidate> findByYouthAcademyId(Long youthAcademyId);
+}

--- a/src/main/java/com/lollito/fm/service/MatchSchedulerService.java
+++ b/src/main/java/com/lollito/fm/service/MatchSchedulerService.java
@@ -20,7 +20,7 @@ public class MatchSchedulerService {
     @Autowired private MatchRepository matchRepository;
     @Autowired private MatchProcessor matchProcessor;
 
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "${fm.match.processing.cron:0 * * * * *}")
     public void processScheduledMatches() {
         LocalDateTime now = LocalDateTime.now();
         List<Match> matchesToRun = matchRepository.findByStatusAndDateBefore(MatchStatus.SCHEDULED, now);

--- a/src/main/java/com/lollito/fm/service/YouthAcademyService.java
+++ b/src/main/java/com/lollito/fm/service/YouthAcademyService.java
@@ -1,0 +1,190 @@
+package com.lollito.fm.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Contract;
+import com.lollito.fm.model.ContractStatus;
+import com.lollito.fm.model.Foot;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.PlayerRole;
+import com.lollito.fm.model.Team;
+import com.lollito.fm.model.YouthAcademy;
+import com.lollito.fm.model.YouthCandidate;
+import com.lollito.fm.repository.rest.ContractRepository;
+import com.lollito.fm.repository.rest.YouthAcademyRepository;
+import com.lollito.fm.repository.rest.YouthCandidateRepository;
+import com.lollito.fm.utils.RandomUtils;
+
+@Service
+public class YouthAcademyService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired private YouthAcademyRepository youthAcademyRepository;
+    @Autowired private YouthCandidateRepository youthCandidateRepository;
+    @Autowired private NameService nameService;
+    @Autowired private PlayerService playerService;
+    @Autowired private ContractRepository contractRepository;
+    @Autowired private ClubService clubService;
+
+    @Value("${fm.youth.generation.count:3}")
+    private Integer generationCount;
+
+    @Value("${fm.youth.quality.multiplier:1.0}")
+    private Double qualityMultiplier;
+
+    @Scheduled(cron = "${fm.youth.generation.cron:0 0 12 * * MON}")
+    @Transactional
+    public void generateYouthCandidates() {
+        logger.info("Starting scheduled youth candidate generation...");
+        List<YouthAcademy> academies = youthAcademyRepository.findAll();
+
+        for (YouthAcademy academy : academies) {
+            try {
+                if (academy.getMaxYouthPlayers() != null && academy.getCandidates().size() >= academy.getMaxYouthPlayers()) {
+                    continue; // Skip if full
+                }
+
+                int count = generationCount;
+
+                for (int i = 0; i < count; i++) {
+                     createCandidate(academy);
+                }
+            } catch (Exception e) {
+                logger.error("Error generating candidates for academy {}", academy.getId(), e);
+            }
+        }
+        logger.info("Completed youth candidate generation.");
+    }
+
+    private YouthCandidate createCandidate(YouthAcademy academy) {
+        String name = RandomUtils.randomValueFromList(nameService.getNames());
+        String surname = RandomUtils.randomValueFromList(nameService.getSurnames());
+        int age = RandomUtils.randomValue(15, 17);
+        LocalDate birth = LocalDate.now().minusYears(age).minusDays(RandomUtils.randomValue(0, 364));
+
+        PlayerRole role = PlayerRole.values()[RandomUtils.randomValue(0, PlayerRole.values().length - 1)];
+        Foot foot = Foot.values()[RandomUtils.randomValue(0, Foot.values().length - 1)];
+
+        double base = 20.0 + ((academy.getOverallQuality() != null ? academy.getOverallQuality() : 1) * 3.0);
+        base *= qualityMultiplier;
+
+        YouthCandidate candidate = YouthCandidate.builder()
+            .name(name)
+            .surname(surname)
+            .birth(birth)
+            .role(role)
+            .preferredFoot(foot)
+            .nationality(academy.getClub().getLeague().getCountry())
+            .youthAcademy(academy)
+            .build();
+
+        // Generate attributes based on role and quality
+        generateAttributes(candidate, base + RandomUtils.randomValue(0.0, 20.0));
+
+        return youthCandidateRepository.save(candidate);
+    }
+
+    private void generateAttributes(YouthCandidate c, double avg) {
+        // Distribute avg around attributes with bias towards role
+        c.setStamina(randomize(avg));
+        c.setPlaymaking(randomize(avg));
+        c.setScoring(randomize(avg));
+        c.setWinger(randomize(avg));
+        c.setGoalkeeping(randomize(avg));
+        c.setPassing(randomize(avg));
+        c.setDefending(randomize(avg));
+        c.setSetPieces(randomize(avg));
+
+        // Boost primary skills
+        double boost = 10.0;
+        switch(c.getRole()) {
+            case GOALKEEPER -> c.setGoalkeeping(c.getGoalkeeping() + boost);
+            case DEFENDER -> c.setDefending(c.getDefending() + boost);
+            case MIDFIELDER -> { c.setPlaymaking(c.getPlaymaking() + boost); c.setPassing(c.getPassing() + boost); }
+            case WING -> { c.setWinger(c.getWinger() + boost); c.setPassing(c.getPassing() + boost); }
+            case FORWARD -> c.setScoring(c.getScoring() + boost);
+        }
+
+        // Cap at 99
+        c.setStamina(Math.min(99.0, c.getStamina()));
+        c.setPlaymaking(Math.min(99.0, c.getPlaymaking()));
+        c.setScoring(Math.min(99.0, c.getScoring()));
+        c.setWinger(Math.min(99.0, c.getWinger()));
+        c.setGoalkeeping(Math.min(99.0, c.getGoalkeeping()));
+        c.setPassing(Math.min(99.0, c.getPassing()));
+        c.setDefending(Math.min(99.0, c.getDefending()));
+        c.setSetPieces(Math.min(99.0, c.getSetPieces()));
+    }
+
+    private Double randomize(double val) {
+        return Math.max(1.0, val + RandomUtils.randomValue(-5.0, 5.0));
+    }
+
+    @Transactional
+    public Player promoteCandidate(Long candidateId) {
+        YouthCandidate candidate = youthCandidateRepository.findById(candidateId)
+            .orElseThrow(() -> new EntityNotFoundException("Candidate not found"));
+
+        Club club = candidate.getYouthAcademy().getClub();
+        Team team = club.getTeam();
+
+        Player player = Player.builder()
+            .name(candidate.getName())
+            .surname(candidate.getSurname())
+            .birth(candidate.getBirth())
+            .role(candidate.getRole())
+            .preferredFoot(candidate.getPreferredFoot())
+            .team(team)
+            .stamina(candidate.getStamina())
+            .playmaking(candidate.getPlaymaking())
+            .scoring(candidate.getScoring())
+            .winger(candidate.getWinger())
+            .goalkeeping(candidate.getGoalkeeping())
+            .passing(candidate.getPassing())
+            .defending(candidate.getDefending())
+            .setPieces(candidate.getSetPieces())
+            .condition(100.0)
+            .moral(100.0)
+            .build();
+
+        player = playerService.save(player);
+
+        // Create default contract
+        Contract contract = Contract.builder()
+            .player(player)
+            .club(club)
+            .weeklySalary(new BigDecimal(1000)) // Default youth salary
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusYears(3)) // 3 years default
+            .status(ContractStatus.ACTIVE)
+            .hasReleaseClause(false)
+            .build();
+
+        contract = contractRepository.save(contract);
+        player.setCurrentContract(contract);
+        player = playerService.save(player);
+
+        // Delete candidate
+        youthCandidateRepository.delete(candidate);
+
+        return player;
+    }
+
+    public List<YouthCandidate> getCandidates(Long academyId) {
+        return youthCandidateRepository.findByYouthAcademyId(academyId);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -114,3 +114,11 @@ fm.watchlist.update.check.time=08:00
 fm.watchlist.value-change.threshold=0.05
 fm.watchlist.performance.threshold=8.0
 fm.watchlist.contract-expiry.warning-months=6
+
+# Youth System Configuration
+fm.youth.generation.cron=0 0 12 * * MON
+fm.youth.generation.count=3
+fm.youth.quality.multiplier=1.0
+
+# Match Processing Configuration
+fm.match.processing.cron=0 * * * * *

--- a/src/test/java/com/lollito/fm/service/TrainingServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/TrainingServiceTest.java
@@ -19,6 +19,7 @@ import com.lollito.fm.model.TrainingSession;
 import com.lollito.fm.repository.PlayerTrainingResultRepository;
 import com.lollito.fm.repository.TrainingPlanRepository;
 import com.lollito.fm.repository.TrainingSessionRepository;
+import com.lollito.fm.repository.rest.ClubRepository;
 
 @ExtendWith(MockitoExtension.class)
 class TrainingServiceTest {
@@ -37,6 +38,12 @@ class TrainingServiceTest {
 
     @Mock
     private TeamService teamService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private StaffService staffService;
 
     @InjectMocks
     private TrainingService trainingService;


### PR DESCRIPTION
Implemented periodic generation of youth candidates in `YouthAcademyService` based on configurable properties.
Added `YouthCandidate` entity, repository, DTO, and Mapper.
Updated `YouthAcademy` to hold candidates.
Created `YouthAcademyController` to expose candidates and promotion endpoint.
Added configuration for generation frequency, count, and quality.
Made match processing frequency configurable.
Fixed `TrainingServiceTest` context loading issue.

---
*PR created automatically by Jules for task [5731393273813535564](https://jules.google.com/task/5731393273813535564) started by @lollito*