### PR TITLE
Fix upcoming matches display by adding @JsonFormat to MatchDTO

### DIFF
--- a/src/main/java/com/lollito/fm/model/dto/MatchDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/MatchDTO.java
@@ -3,6 +3,7 @@ package com.lollito.fm.model.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lollito.fm.model.MatchStatus;
 
 import lombok.AllArgsConstructor;
@@ -20,6 +21,7 @@ public class MatchDTO {
     private ClubDTO away;
     private Integer homeScore;
     private Integer awayScore;
+    @JsonFormat (shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm")
     private LocalDateTime date;
     private Boolean finish;
     private MatchStatus status;


### PR DESCRIPTION
The `/upcoming-matches` page was failing to display data because the `MatchDTO` serialization of the `date` field did not match the format expected by the frontend. The frontend expected "dd-MM-yyyy HH:mm" but received the default Jackson serialization for `LocalDateTime`. This change applies `@JsonFormat` to `MatchDTO.date` to ensure consistent serialization, resolving the display issue.

---
*PR created automatically by Jules for task [3668479165572039967](https://jules.google.com/task/3668479165572039967) started by @lollito*