### PR TITLE
Fix missing lineups and player ratings in match details

### DIFF
--- a/src/main/java/com/lollito/fm/mapper/MatchMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/MatchMapper.java
@@ -9,7 +9,7 @@ import com.lollito.fm.model.dto.StatsDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = {ClubMapper.class})
+@Mapper(componentModel = "spring", uses = {ClubMapper.class, FormationMapper.class, MatchPlayerStatsMapper.class})
 public interface MatchMapper {
 
     @Mapping(source = "number", target = "roundNumber")

--- a/src/main/java/com/lollito/fm/mapper/MatchPlayerStatsMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/MatchPlayerStatsMapper.java
@@ -1,0 +1,11 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.MatchPlayerStats;
+import com.lollito.fm.model.dto.MatchPlayerStatsDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", uses = {PlayerMapper.class})
+public interface MatchPlayerStatsMapper {
+    MatchPlayerStatsDTO toDto(MatchPlayerStats matchPlayerStats);
+    MatchPlayerStats toEntity(MatchPlayerStatsDTO matchPlayerStatsDTO);
+}

--- a/src/main/java/com/lollito/fm/model/dto/MatchDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/MatchDTO.java
@@ -28,6 +28,10 @@ public class MatchDTO {
     private List<EventHistoryDTO> events;
     private StatsDTO stats;
 
+    private FormationDTO homeFormation;
+    private FormationDTO awayFormation;
+    private List<MatchPlayerStatsDTO> playerStats;
+
     // Transient fields from Match entity logic
     private Integer roundNumber;
     private String competitionName;

--- a/src/main/java/com/lollito/fm/model/dto/MatchPlayerStatsDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/MatchPlayerStatsDTO.java
@@ -1,0 +1,28 @@
+package com.lollito.fm.model.dto;
+
+import com.lollito.fm.dto.PlayerDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchPlayerStatsDTO {
+    private Long id;
+    private PlayerDTO player;
+    private Integer goals;
+    private Integer assists;
+    private Integer yellowCards;
+    private Integer redCards;
+    private Integer shots;
+    private Integer shotsOnTarget;
+    private Integer passes;
+    private Integer completedPasses;
+    private Integer tackles;
+    private Double rating;
+    private Boolean mvp;
+    private String position;
+}

--- a/src/test/java/com/lollito/fm/mapper/MatchMapperTest.java
+++ b/src/test/java/com/lollito/fm/mapper/MatchMapperTest.java
@@ -1,0 +1,79 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.*;
+import com.lollito.fm.model.dto.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class MatchMapperTest {
+
+    @Autowired
+    private MatchMapper matchMapper;
+
+    @Test
+    public void testToDto_WithFormationsAndStats() {
+        // Setup Match
+        Match match = new Match();
+        match.setId(1L);
+
+        Round round = new Round();
+        round.setNumber(1);
+        match.setRound(round);
+
+        // Setup Formations
+        Formation homeFormation = new Formation();
+        homeFormation.setId(10L);
+        match.setHomeFormation(homeFormation);
+
+        Formation awayFormation = new Formation();
+        awayFormation.setId(20L);
+        match.setAwayFormation(awayFormation);
+
+        // Setup Player Stats
+        List<MatchPlayerStats> statsList = new ArrayList<>();
+        MatchPlayerStats stats = new MatchPlayerStats();
+        stats.setId(100L);
+        stats.setGoals(2);
+        stats.setRating(8.5);
+
+        Player player = new Player();
+        player.setId(50L);
+        player.setName("John");
+        player.setSurname("Doe");
+        player.setBirth(java.time.LocalDate.of(2000, 1, 1));
+        stats.setPlayer(player);
+
+        statsList.add(stats);
+        match.setPlayerStats(statsList);
+
+        // Execute mapping
+        MatchDTO dto = matchMapper.toDto(match);
+
+        // Verify
+        assertNotNull(dto);
+        assertNotNull(dto.getHomeFormation());
+        assertEquals(10L, dto.getHomeFormation().getId());
+
+        assertNotNull(dto.getAwayFormation());
+        assertEquals(20L, dto.getAwayFormation().getId());
+
+        assertNotNull(dto.getPlayerStats());
+        assertEquals(1, dto.getPlayerStats().size());
+        MatchPlayerStatsDTO statsDto = dto.getPlayerStats().get(0);
+        assertEquals(100L, statsDto.getId());
+        assertEquals(2, statsDto.getGoals());
+        assertEquals(8.5, statsDto.getRating());
+
+        assertNotNull(statsDto.getPlayer());
+        assertEquals(50L, statsDto.getPlayer().getId());
+        assertEquals("John", statsDto.getPlayer().getName());
+        assertEquals("Doe", statsDto.getPlayer().getSurname());
+    }
+}


### PR DESCRIPTION
This PR fixes the issue where lineups and player ratings were not visible on the match details page. 
It ensures that the `MatchDTO` returned by the API includes the necessary formation and statistics data.

Changes:
- Added `MatchPlayerStatsDTO.java`
- Added `MatchPlayerStatsMapper.java`
- Updated `MatchDTO.java`
- Updated `MatchMapper.java`
- Added `MatchMapperTest.java`

---
*PR created automatically by Jules for task [7144614604364140057](https://jules.google.com/task/7144614604364140057) started by @lollito*