### PR TITLE
Migrate LiveMatchSession to Embedded MongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,41 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongodb-driver-sync</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongodb-driver-core</artifactId>
+                </exclusion>
+            </exclusions>
+		</dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.11.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
+            <version>4.11.1</version>
+        </dependency>
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<version>4.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
+			<version>4.9.2</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>

--- a/src/main/java/com/lollito/fm/model/LiveMatchSession.java
+++ b/src/main/java/com/lollito/fm/model/LiveMatchSession.java
@@ -3,21 +3,16 @@ package com.lollito.fm.model;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-import jakarta.persistence.Column;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.index.Indexed;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Entity
-@Table(name = "fm_live_match_session")
+@Document(collection = "fm_live_match_session")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -27,10 +22,9 @@ public class LiveMatchSession implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
-    @Column(unique = true)
+    @Indexed(unique = true)
     private Long matchId;
 
     private LocalDateTime startTime;
@@ -44,16 +38,10 @@ public class LiveMatchSession implements Serializable {
     @Builder.Default
     private Integer awayScore = 0;
 
-    @Lob
-    @Column(columnDefinition = "TEXT")
     private String events; // JSON of List<EventHistoryDTO>
 
-    @Lob
-    @Column(columnDefinition = "TEXT")
     private String stats; // JSON of StatsDTO
 
-    @Lob
-    @Column(columnDefinition = "TEXT")
     private String playerStats; // JSON of List<MatchPlayerStatsDTO>
 
     @Builder.Default

--- a/src/main/java/com/lollito/fm/model/MatchEvent.java
+++ b/src/main/java/com/lollito/fm/model/MatchEvent.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,9 +36,8 @@ public class MatchEvent {
     @JoinColumn(name = "match_id")
     private Match match;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "session_id")
-    private LiveMatchSession session;
+    @Column(name = "session_id")
+    private String sessionId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")

--- a/src/main/java/com/lollito/fm/model/dto/LiveMatchSessionDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/LiveMatchSessionDTO.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LiveMatchSessionDTO {
-    private Long id;
+    private String id;
     private Match match; // Or MatchDTO if it exists, but task uses Match
     private MatchPhase currentPhase;
     private Integer currentMinute;

--- a/src/main/java/com/lollito/fm/repository/rest/LiveMatchSessionRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/LiveMatchSessionRepository.java
@@ -1,14 +1,14 @@
 package com.lollito.fm.repository.rest;
 
 import com.lollito.fm.model.LiveMatchSession;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface LiveMatchSessionRepository extends JpaRepository<LiveMatchSession, Long> {
+public interface LiveMatchSessionRepository extends MongoRepository<LiveMatchSession, String> {
     Optional<LiveMatchSession> findByMatchId(Long matchId);
     List<LiveMatchSession> findByFinishedFalse();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,10 @@ spring.datasource.driver-class-name=org.h2.Driver
 #spring.h2.console.enabled=true
 #spring.h2.console.path=/h2
 
+# MongoDB (Embedded for Dev)
+spring.data.mongodb.auto-index-creation=true
+de.flapdoodle.mongodb.embedded.version=4.0.25
+
 
 
 #spring.data.rest.base-path=/api


### PR DESCRIPTION
This PR migrates the `LiveMatchSession` entity from H2 (JPA) to an embedded MongoDB instance for development purposes, solving the DDL error regarding `TEXT` types in H2.

Key changes:
1.  **Dependencies:** Added Spring Data MongoDB and Flapdoodle Embedded Mongo. Downgraded Mongo Driver to 4.11.1 to support the 4.0.x embedded server available in the environment.
2.  **Entity Migration:** `LiveMatchSession` is now a `@Document` with a String ID. The potentially large JSON fields (`events`, `stats`, `playerStats`) are stored naturally in Mongo.
3.  **Repository:** Switched to `MongoRepository`.
4.  **JPA Compatibility:** Updated `MatchEvent` to use a loose coupling (`sessionId` String) instead of a direct JPA `@ManyToOne` relationship to the now-Mongo-based `LiveMatchSession`.
5.  **Configuration:** Added necessary properties to `application.properties` for embedded Mongo versioning.

This allows `LiveMatchSession` to handle high-frequency updates and flexible JSON structures better than H2, while keeping the rest of the application on the SQL database.

---
*PR created automatically by Jules for task [12155697195260832334](https://jules.google.com/task/12155697195260832334) started by @lollito*