### PR TITLE
Fix Hibernate orphan removal exception in MatchProcessor

### DIFF
--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -63,9 +63,9 @@ public class MatchProcessor {
         // Reset match to started state (scores 0-0)
         match.setHomeScore(0);
         match.setAwayScore(0);
-        match.setEvents(new ArrayList<>());
+        match.getEvents().clear();
         match.setStats(new Stats());
-        match.setPlayerStats(new ArrayList<>());
+        match.getPlayerStats().clear();
         match.setFinish(false);
         match.setStatus(MatchStatus.IN_PROGRESS);
 
@@ -95,7 +95,8 @@ public class MatchProcessor {
             // Restore Events
             List<EventHistoryDTO> eventDTOs = objectMapper.readValue(session.getEvents(), new TypeReference<List<EventHistoryDTO>>(){});
             List<EventHistory> events = eventDTOs.stream().map(matchMapper::toEntity).collect(Collectors.toList());
-            match.setEvents(events);
+            match.getEvents().clear();
+            match.getEvents().addAll(events);
 
             // Restore Stats
             StatsDTO statsDTO = objectMapper.readValue(session.getStats(), StatsDTO.class);
@@ -108,7 +109,8 @@ public class MatchProcessor {
                         .map(matchPlayerStatsMapper::toEntity)
                         .collect(Collectors.toList());
                 playerStats.forEach(mps -> mps.setMatch(match));
-                match.setPlayerStats(playerStats);
+                match.getPlayerStats().clear();
+                match.getPlayerStats().addAll(playerStats);
             }
 
             match.setFinish(true);


### PR DESCRIPTION
This PR fixes a critical backend issue where `MatchProcessor.processMatch` and `MatchProcessor.finalizeMatch` were throwing `org.hibernate.HibernateException: A collection with orphan deletion was no longer referenced by the owning entity instance` for the `Match.events` collection.

The issue was caused by assigning a new `ArrayList` to the `events` field (e.g., `match.setEvents(new ArrayList<>())`), which disconnected the Hibernate-managed `PersistentBag` from the entity. Since `events` is configured with `orphanRemoval = true`, Hibernate flagged this as an error.

The fix involves changing the logic to clear the existing collection (`match.getEvents().clear()`) and add new elements (`match.getEvents().addAll(events)`) if necessary, ensuring the persistent collection wrapper is preserved. The same fix was applied to `playerStats` for consistency and safety.

Verified by code review and compilation. Existing tests `LiveMatchServiceTest` passed.

---
*PR created automatically by Jules for task [3977766161002405127](https://jules.google.com/task/3977766161002405127) started by @lollito*