### PR TITLE
Fix blank live match events by updating EventHistoryDTO

### DIFF
--- a/src/main/java/com/lollito/fm/mapper/MatchMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/MatchMapper.java
@@ -22,6 +22,8 @@ public interface MatchMapper {
     Stats toEntity(StatsDTO statsDTO);
 
     @Mapping(target = "eventType", expression = "java(mapEventType(eventHistory.getType()))")
+    @Mapping(source = "event", target = "description")
+    @Mapping(target = "isKeyEvent", expression = "java(isKeyEvent(eventHistory.getType()))")
     EventHistoryDTO toDto(EventHistory eventHistory);
 
     EventHistory toEntity(EventHistoryDTO eventHistoryDTO);
@@ -39,6 +41,18 @@ public interface MatchMapper {
             case SUBSTITUTION: return "SUBSTITUTION";
             case INJURY: return "INJURY";
             default: return "NORMAL";
+        }
+    }
+
+    default Boolean isKeyEvent(Event event) {
+        if (event == null) return false;
+        switch (event) {
+            case HAVE_SCORED:
+            case HAVE_SCORED_FREE_KICK:
+            case RED_CARD:
+                return true;
+            default:
+                return false;
         }
     }
 }

--- a/src/main/java/com/lollito/fm/model/dto/EventHistoryDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/EventHistoryDTO.java
@@ -18,4 +18,6 @@ public class EventHistoryDTO {
     private Integer homeScore;
     private Integer awayScore;
     private String eventType;
+    private String description;
+    private Boolean isKeyEvent;
 }


### PR DESCRIPTION
- Added `description` and `isKeyEvent` fields to `EventHistoryDTO` to match `LiveMatchViewer.js` expectations.
- Updated `MatchMapper` to populate `description` from `EventHistory.event` and calculate `isKeyEvent` based on event type.
- This resolves the issue where live match events were rendered as blank lines.

---
*PR created automatically by Jules for task [16997800346577020239](https://jules.google.com/task/16997800346577020239) started by @lollito*