### PR TITLE
Fix Entity JSON Recursion Bugs

### DIFF
--- a/src/main/java/com/lollito/fm/model/AdminAction.java
+++ b/src/main/java/com/lollito/fm/model/AdminAction.java
@@ -13,6 +13,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -39,6 +41,7 @@ public class AdminAction {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "admin_user_id")
     @ToString.Exclude
+    @JsonIgnore
     private User adminUser;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lollito/fm/model/MaintenanceRecord.java
+++ b/src/main/java/com/lollito/fm/model/MaintenanceRecord.java
@@ -16,6 +16,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -70,6 +72,7 @@ public class MaintenanceRecord implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     @ToString.Exclude
+    @JsonIgnore
     private Club club;
 
     private String contractorName;

--- a/src/main/java/com/lollito/fm/model/UserActivity.java
+++ b/src/main/java/com/lollito/fm/model/UserActivity.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -39,6 +41,7 @@ public class UserActivity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @ToString.Exclude
+    @JsonIgnore
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lollito/fm/model/UserNotification.java
+++ b/src/main/java/com/lollito/fm/model/UserNotification.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -39,6 +41,7 @@ public class UserNotification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @ToString.Exclude
+    @JsonIgnore
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lollito/fm/model/UserSession.java
+++ b/src/main/java/com/lollito/fm/model/UserSession.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -39,6 +41,7 @@ public class UserSession {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @ToString.Exclude
+    @JsonIgnore
     private User user;
 
     private String sessionId;


### PR DESCRIPTION
This PR addresses the issue reported in `bug_04_entity_json_recursion.md` where bidirectional relationships in JPA entities were causing infinite recursion and performance issues during JSON serialization.

Changes:
- Added `@JsonIgnore` to `MaintenanceRecord.club`.
- Added `@JsonIgnore` to `UserSession.user`.
- Added `@JsonIgnore` to `UserActivity.user`.
- Added `@JsonIgnore` to `UserNotification.user`.
- Added `@JsonIgnore` to `AdminAction.adminUser`.
- Added necessary imports for `com.fasterxml.jackson.annotation.JsonIgnore`.

Verification:
- Created a reproduction test `Bug04ReproductionTest` which confirmed the recursion/serialization issues.
- Verified that applying the fixes resolved the recursion and prevented unwanted serialization of parent entities.
- The reproduction test passed after fixes were applied.


---
*PR created automatically by Jules for task [12142969595183059192](https://jules.google.com/task/12142969595183059192) started by @lollito*