### PR TITLE
Refactor InfrastructureController to return MaintenanceRecordDTO

### DIFF
--- a/src/main/java/com/lollito/fm/controller/InfrastructureController.java
+++ b/src/main/java/com/lollito/fm/controller/InfrastructureController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lollito.fm.mapper.MaintenanceMapper;
 import com.lollito.fm.model.FacilityType;
 import com.lollito.fm.model.MaintenanceRecord;
 import com.lollito.fm.model.dto.FacilityUpgradeDTO;
 import com.lollito.fm.model.dto.InfrastructureOverviewDTO;
+import com.lollito.fm.model.dto.MaintenanceRecordDTO;
 import com.lollito.fm.model.dto.ScheduleMaintenanceRequest;
 import com.lollito.fm.model.dto.StartUpgradeRequest;
 import com.lollito.fm.model.dto.UpgradeOptionDTO;
@@ -26,6 +28,9 @@ public class InfrastructureController {
 
     @Autowired
     private InfrastructureService infrastructureService;
+
+    @Autowired
+    private MaintenanceMapper maintenanceMapper;
 
     @GetMapping("/club/{clubId}/overview")
     public ResponseEntity<InfrastructureOverviewDTO> getInfrastructureOverview(@PathVariable Long clubId) {
@@ -56,16 +61,16 @@ public class InfrastructureController {
     }
 
     @GetMapping("/club/{clubId}/maintenance/schedule")
-    public ResponseEntity<List<MaintenanceRecord>> getMaintenanceSchedule(@PathVariable Long clubId) {
+    public ResponseEntity<List<MaintenanceRecordDTO>> getMaintenanceSchedule(@PathVariable Long clubId) {
         List<MaintenanceRecord> maintenance = infrastructureService.getMaintenanceSchedule(clubId);
-        return ResponseEntity.ok(maintenance);
+        return ResponseEntity.ok(maintenanceMapper.toDtoList(maintenance));
     }
 
     @PostMapping("/club/{clubId}/maintenance/schedule")
-    public ResponseEntity<MaintenanceRecord> scheduleMaintenance(
+    public ResponseEntity<MaintenanceRecordDTO> scheduleMaintenance(
             @PathVariable Long clubId,
             @RequestBody ScheduleMaintenanceRequest request) {
         MaintenanceRecord maintenance = infrastructureService.scheduleMaintenance(clubId, request);
-        return ResponseEntity.ok(maintenance);
+        return ResponseEntity.ok(maintenanceMapper.toDto(maintenance));
     }
 }

--- a/src/main/java/com/lollito/fm/mapper/MaintenanceMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/MaintenanceMapper.java
@@ -1,0 +1,12 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.MaintenanceRecord;
+import com.lollito.fm.model.dto.MaintenanceRecordDTO;
+import org.mapstruct.Mapper;
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface MaintenanceMapper {
+    MaintenanceRecordDTO toDto(MaintenanceRecord record);
+    List<MaintenanceRecordDTO> toDtoList(List<MaintenanceRecord> records);
+}

--- a/src/test/java/com/lollito/fm/mapper/MaintenanceMapperTest.java
+++ b/src/test/java/com/lollito/fm/mapper/MaintenanceMapperTest.java
@@ -1,0 +1,73 @@
+package com.lollito.fm.mapper;
+
+import com.lollito.fm.model.FacilityType;
+import com.lollito.fm.model.MaintenanceRecord;
+import com.lollito.fm.model.MaintenanceStatus;
+import com.lollito.fm.model.MaintenanceType;
+import com.lollito.fm.model.dto.MaintenanceRecordDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class MaintenanceMapperTest {
+
+    @Autowired
+    private MaintenanceMapper maintenanceMapper;
+
+    @Test
+    public void testToDto() {
+        MaintenanceRecord record = new MaintenanceRecord();
+        record.setId(1L);
+        record.setFacilityType(FacilityType.STADIUM);
+        record.setFacilityId(10L);
+        record.setMaintenanceType(MaintenanceType.CORRECTIVE);
+        record.setDescription("Fix seats");
+        record.setCost(BigDecimal.valueOf(1000));
+        record.setStatus(MaintenanceStatus.SCHEDULED);
+        record.setScheduledDate(LocalDate.now());
+        record.setCompletedDate(LocalDate.now().plusDays(1));
+        record.setQualityRestored(5);
+        record.setIssuesFound("Broken seats");
+        record.setWorkPerformed("Replaced seats");
+        record.setContractorName("BuildCorp");
+        record.setIsEmergencyMaintenance(true);
+
+        MaintenanceRecordDTO dto = maintenanceMapper.toDto(record);
+
+        assertNotNull(dto);
+        assertEquals(record.getId(), dto.getId());
+        assertEquals(record.getFacilityType(), dto.getFacilityType());
+        assertEquals(record.getFacilityId(), dto.getFacilityId());
+        assertEquals(record.getMaintenanceType(), dto.getMaintenanceType());
+        assertEquals(record.getDescription(), dto.getDescription());
+        assertEquals(record.getCost(), dto.getCost());
+        assertEquals(record.getStatus(), dto.getStatus());
+        assertEquals(record.getScheduledDate(), dto.getScheduledDate());
+        assertEquals(record.getCompletedDate(), dto.getCompletedDate());
+        assertEquals(record.getQualityRestored(), dto.getQualityRestored());
+        assertEquals(record.getIssuesFound(), dto.getIssuesFound());
+        assertEquals(record.getWorkPerformed(), dto.getWorkPerformed());
+        assertEquals(record.getContractorName(), dto.getContractorName());
+        assertEquals(record.getIsEmergencyMaintenance(), dto.getIsEmergencyMaintenance());
+    }
+
+    @Test
+    public void testToDtoList() {
+        MaintenanceRecord record = new MaintenanceRecord();
+        record.setId(1L);
+
+        List<MaintenanceRecordDTO> dtos = maintenanceMapper.toDtoList(Collections.singletonList(record));
+
+        assertNotNull(dtos);
+        assertEquals(1, dtos.size());
+        assertEquals(record.getId(), dtos.get(0).getId());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -31,3 +31,5 @@ fm.live-match.event.probability.base=0.15
 fm.live-match.additional-time.max=5
 fm.live-match.websocket.heartbeat=30000
 fm.live-match.spectator.timeout=300000
+
+de.flapdoodle.mongodb.embedded.version=4.0.25


### PR DESCRIPTION
This PR addresses the issue where `InfrastructureController` was returning `MaintenanceRecord` entities directly. 
I have introduced a `MaintenanceMapper` using MapStruct and updated the controller endpoints to return `MaintenanceRecordDTO`. 
I also added a unit test for the mapper and fixed a configuration issue for embedded MongoDB in tests.

---
*PR created automatically by Jules for task [3105577428911467786](https://jules.google.com/task/3105577428911467786) started by @lollito*