### PR TITLE
Whitelist WebSocket endpoint to fix Unauthorized error

### DIFF
--- a/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
@@ -39,6 +39,7 @@ public class WebSecurityConfig {
 			"/swagger-ui/**",
 			"/api/country/",
 			"/api/server/findAll",
+			"/ws/live-match/**",
 	};
 	
 	@Qualifier("userDetailsServiceImpl")

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -31,3 +31,5 @@ fm.live-match.event.probability.base=0.15
 fm.live-match.additional-time.max=5
 fm.live-match.websocket.heartbeat=30000
 fm.live-match.spectator.timeout=300000
+
+de.flapdoodle.mongodb.embedded.version=4.0.25


### PR DESCRIPTION
Added `/ws/live-match/**` to the `AUTH_WHITELIST` in `WebSecurityConfig.java` to allow unauthenticated WebSocket/SockJS handshake requests. This resolves the "Unauthorized error: Full authentication is required to access this resource" observed in the frontend logs. Also updated `src/test/resources/application.properties` to fix test execution.

---
*PR created automatically by Jules for task [7615067983164909948](https://jules.google.com/task/7615067983164909948) started by @lollito*