### PR TITLE
Fix PageImpl serialization and test configuration

### DIFF
--- a/src/main/java/com/lollito/fm/FmApplication.java
+++ b/src/main/java/com/lollito/fm/FmApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -14,6 +15,7 @@ import com.lollito.fm.utils.NameGenerator;
 //@EntityScan(
 //        basePackageClasses = {FmApplication.class, Jsr310JpaConverters.class}
 //)
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 @EnableAspectJAutoProxy
 @EnableScheduling
 @EnableAsync

--- a/src/test/java/com/lollito/fm/PageSerializationTest.java
+++ b/src/test/java/com/lollito/fm/PageSerializationTest.java
@@ -1,0 +1,36 @@
+package com.lollito.fm;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class PageSerializationTest {
+
+    @Autowired
+    private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+
+    @Test
+    public void testPageSerialization() throws IOException {
+        Page<String> page = new PageImpl<>(List.of("test"), PageRequest.of(0, 10), 1);
+        String json = objectMapper.writeValueAsString(page);
+
+        System.out.println("Serialized Page: " + json);
+
+        // With VIA_DTO, the structure should include "content" and a "page" object for metadata
+        assertThat(json).contains("\"content\":[\"test\"]");
+        assertThat(json).contains("\"page\":{");
+        assertThat(json).contains("\"size\":10");
+        assertThat(json).contains("\"totalElements\":1");
+        assertThat(json).contains("\"totalPages\":1");
+        assertThat(json).contains("\"number\":0");
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -31,3 +31,5 @@ fm.live-match.event.probability.base=0.15
 fm.live-match.additional-time.max=5
 fm.live-match.websocket.heartbeat=30000
 fm.live-match.spectator.timeout=300000
+
+de.flapdoodle.mongodb.embedded.version=4.0.25


### PR DESCRIPTION
Enables VIA_DTO serialization for Page objects in Spring Data Web Support to resolve unstable JSON structure warnings. Also fixes test execution by configuring embedded MongoDB version.

---
*PR created automatically by Jules for task [11543143424576744485](https://jules.google.com/task/11543143424576744485) started by @lollito*