### PR TITLE
Fix ranking update timing for live matches

### DIFF
--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -43,6 +43,7 @@ public class MatchProcessor {
     @Autowired private MatchPlayerStatsMapper matchPlayerStatsMapper;
     @Autowired private PlayerService playerService;
     @Autowired private PlayerHistoryService playerHistoryService;
+    @Autowired private RankingService rankingService;
 
     @Async
     @Transactional
@@ -55,7 +56,7 @@ public class MatchProcessor {
         logger.info("Processing match {} : {} vs {}", match.getId(), match.getHome().getName(), match.getAway().getName());
 
         // Simulate to get result
-        simulationMatchService.simulate(match);
+        simulationMatchService.simulate(match, null, false);
 
         // Create session with the result
         liveMatchService.createSession(match);
@@ -146,6 +147,7 @@ public class MatchProcessor {
             // So I DON'T need to re-run `playerHistoryService` updates.
             // I ONLY need to restore `Match.playerStats` so the match report is correct.
 
+            rankingService.update(match);
             checkRoundAndSeasonProgression(match);
 
             // Cleanup session?

--- a/src/main/java/com/lollito/fm/service/SimulationMatchService.java
+++ b/src/main/java/com/lollito/fm/service/SimulationMatchService.java
@@ -60,7 +60,7 @@ public class SimulationMatchService {
 		return simulate(match, forcedResult, true);
 	}
 
-	private MatchResult simulate(Match match, String forcedResult, boolean updateRanking) {
+	public MatchResult simulate(Match match, String forcedResult, boolean updateRanking) {
 		Integer stadiumCapacity = stadiumService.getCapacity(match.getHome().getStadium());
 		match.setSpectators(RandomUtils.randomValue(stadiumCapacity/3, stadiumCapacity));
 		


### PR DESCRIPTION
This PR fixes a bug where league rankings were updated at the beginning of a live match simulation instead of at the end. 

Key changes:
- `SimulationMatchService.java`: Exposed the `simulate` method with a boolean flag to control ranking updates.
- `MatchProcessor.java`: 
    - Disabled ranking updates during the initial simulation phase (`updateRanking=false`).
    - Added a call to `rankingService.update(match)` in the `finalizeMatch` method to ensure rankings are updated only when the match is officially completed.

This ensures that the "Classifica" (Rankings) remains accurate during live matches and only reflects the results of completed games.

---
*PR created automatically by Jules for task [3139315250903172590](https://jules.google.com/task/3139315250903172590) started by @lollito*