### PR TITLE
Add Live Match Monitoring to Admin Panel

### DIFF
--- a/fm-admin/src/App.js
+++ b/fm-admin/src/App.js
@@ -8,6 +8,7 @@ import DebugTools from './pages/DebugTools';
 import AdminDashboard from './pages/AdminDashboard';
 import ClubManagement from './pages/ClubManagement';
 import ServerManagement from './pages/ServerManagement';
+import LiveMatchMonitoring from './pages/LiveMatchMonitoring';
 
 const PrivateRoute = ({ children }) => {
   const { user } = useContext(AuthContext);
@@ -34,6 +35,7 @@ function App() {
           <Route path="/clubs" element={<PrivateRoute><ClubManagement /></PrivateRoute>} />
           <Route path="/users" element={<PrivateRoute><UserManagement /></PrivateRoute>} />
           <Route path="/servers" element={<PrivateRoute><ServerManagement /></PrivateRoute>} />
+          <Route path="/live-matches" element={<PrivateRoute><LiveMatchMonitoring /></PrivateRoute>} />
           <Route path="/debug" element={<PrivateRoute><DebugTools /></PrivateRoute>} />
         </Routes>
       </Router>

--- a/fm-admin/src/components/Sidebar.js
+++ b/fm-admin/src/components/Sidebar.js
@@ -36,6 +36,13 @@ const Sidebar = () => {
         </Link>
       </li>
 
+      <li className={'nav-item ' + (location.pathname === '/live-matches' ? 'active' : '')}>
+        <Link className="nav-link" to="/live-matches">
+          <i className="fas fa-fw fa-video"></i>
+          <span> Live Matches</span>
+        </Link>
+      </li>
+
       <hr className="sidebar-divider" />
     </ul>
   );

--- a/fm-admin/src/pages/LiveMatchMonitoring.js
+++ b/fm-admin/src/pages/LiveMatchMonitoring.js
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { getAllLiveMatches } from '../services/api';
+import Layout from '../components/Layout';
+
+const LiveMatchMonitoring = () => {
+    const [matches, setMatches] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const fetchMatches = async () => {
+        try {
+            // Don't set loading to true on refresh to avoid flickering
+            // setLoading(true);
+            const response = await getAllLiveMatches();
+            setMatches(response.data);
+            setError(null);
+        } catch (err) {
+            console.error("Error fetching live matches", err);
+            setError("Failed to load live matches.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        // Initial load
+        setLoading(true);
+        fetchMatches();
+
+        const interval = setInterval(fetchMatches, 10000); // Auto refresh every 10s
+        return () => clearInterval(interval);
+    }, []);
+
+    const liveMatches = matches.filter(m => !m.finished);
+    const finishedMatches = matches.filter(m => m.finished);
+
+    if (loading && matches.length === 0) return (
+        <Layout>
+            <div className="p-4">Loading...</div>
+        </Layout>
+    );
+
+    return (
+        <Layout>
+            <div className="container-fluid p-4">
+                <h1 className="h3 mb-4 text-gray-800">Live Match Monitoring</h1>
+
+                {error && <div className="alert alert-danger">{error}</div>}
+
+                <div className="card shadow mb-4">
+                    <div className="card-header py-3">
+                        <h6 className="m-0 font-weight-bold text-primary">Live Matches ({liveMatches.length})</h6>
+                    </div>
+                    <div className="card-body">
+                        <MatchTable matches={liveMatches} live={true} />
+                    </div>
+                </div>
+
+                <div className="card shadow mb-4">
+                    <div className="card-header py-3">
+                        <h6 className="m-0 font-weight-bold text-success">Finished Matches ({finishedMatches.length})</h6>
+                    </div>
+                    <div className="card-body">
+                        <MatchTable matches={finishedMatches} live={false} />
+                    </div>
+                </div>
+            </div>
+        </Layout>
+    );
+};
+
+const MatchTable = ({ matches, live }) => {
+    if (matches.length === 0) return <p>No matches found.</p>;
+
+    return (
+        <div className="table-responsive">
+            <table className="table table-bordered" width="100%" cellSpacing="0">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Start Time</th>
+                        <th>Home</th>
+                        <th>Score</th>
+                        <th>Away</th>
+                        <th>Minute</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {matches.map(match => (
+                        <tr key={match.sessionId}>
+                            <td>{match.matchId}</td>
+                            <td>{new Date(match.startTime).toLocaleString()}</td>
+                            <td className="font-weight-bold">{match.homeTeamName}</td>
+                            <td className="text-center">{match.homeScore} - {match.awayScore}</td>
+                            <td className="font-weight-bold">{match.awayTeamName}</td>
+                            <td>{match.currentMinute}'</td>
+                            <td>
+                                {live ? (
+                                    <span className="badge badge-danger">LIVE</span>
+                                ) : (
+                                    <span className="badge badge-secondary">Finished</span>
+                                )}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default LiveMatchMonitoring;

--- a/fm-admin/src/services/api.js
+++ b/fm-admin/src/services/api.js
@@ -47,4 +47,6 @@ export const updateSystemConfiguration = (id, newValue) => api.put(`/admin/confi
 export const getServers = () => api.get('/server/findAll');
 export const createServer = (serverName) => api.post('/server/?serverName=' + serverName);
 
+export const getAllLiveMatches = () => api.get('/live-match/all');
+
 export default api;

--- a/src/main/java/com/lollito/fm/controller/LiveMatchController.java
+++ b/src/main/java/com/lollito/fm/controller/LiveMatchController.java
@@ -1,9 +1,12 @@
 package com.lollito.fm.controller;
 
+import com.lollito.fm.model.dto.LiveMatchSummaryDTO;
 import com.lollito.fm.service.LiveMatchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/live-match")
@@ -15,6 +18,11 @@ public class LiveMatchController {
     @GetMapping("/{id}")
     public ResponseEntity<Object> getLiveMatch(@PathVariable Long id) {
         return ResponseEntity.ok(liveMatchService.getLiveMatchData(id));
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<LiveMatchSummaryDTO>> getAllLiveMatches() {
+        return ResponseEntity.ok(liveMatchService.getAllLiveMatchSummaries());
     }
 
     @PostMapping("/{id}/join")

--- a/src/main/java/com/lollito/fm/model/dto/LiveMatchSummaryDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/LiveMatchSummaryDTO.java
@@ -1,0 +1,25 @@
+package com.lollito.fm.model.dto;
+
+import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LiveMatchSummaryDTO {
+    private String sessionId;
+    private Long matchId;
+    private String homeTeamName;
+    private String awayTeamName;
+    private Integer homeScore;
+    private Integer awayScore;
+    private Integer currentMinute;
+    private Boolean finished;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm")
+    private LocalDateTime startTime;
+}


### PR DESCRIPTION
Added a new page in fm-admin to monitor live matches.
- Created `LiveMatchSummaryDTO` for efficient data transfer.
- Updated `LiveMatchService` and `LiveMatchController` to expose all live matches.
- Added frontend route `/live-matches` and `LiveMatchMonitoring` component.
- Updated Sidebar navigation.

---
*PR created automatically by Jules for task [731420936173719854](https://jules.google.com/task/731420936173719854) started by @lollito*