### PR TITLE
Refactor Team Page UI and Fix Training Tabs

### DIFF
--- a/fm-web/src/components/TrainingHistory.js
+++ b/fm-web/src/components/TrainingHistory.js
@@ -16,9 +16,11 @@ const TrainingHistory = ({ teamId }) => {
     const loadTrainingHistory = async () => {
         try {
             const response = await getTrainingHistory(teamId);
-            setSessions(response.data.content);
+            const content = response.data?.content || (Array.isArray(response.data) ? response.data : []);
+            setSessions(content);
         } catch (error) {
             console.error('Error loading training history:', error);
+            setSessions([]);
         } finally {
             setLoading(false);
         }
@@ -71,14 +73,14 @@ const TrainingHistory = ({ teamId }) => {
                     >
                         <div className="session-header" style={{ display: 'flex', justifyContent: 'space-between' }}>
                             <span className="session-date" style={{ fontWeight: 'bold' }}>
-                                {new Date(session.startDate).toLocaleDateString()}
+                                {session.startDate ? new Date(session.startDate).toLocaleDateString() : 'N/A'}
                             </span>
                             <span className="session-focus">{session.focus}</span>
                             <span className="session-intensity">{session.intensity}</span>
                         </div>
                         <div className="session-stats" style={{ fontSize: '0.9em', color: '#666', marginTop: '5px' }}>
                             <span style={{ marginRight: '15px' }}>Players trained: {session.playerResults ? session.playerResults.length : 'N/A'}</span>
-                            <span>Effectiveness: {Math.round(session.effectivenessMultiplier * 100)}%</span>
+                            <span>Effectiveness: {session.effectivenessMultiplier ? Math.round(session.effectivenessMultiplier * 100) : 0}%</span>
                         </div>
                     </div>
                 ))}
@@ -102,10 +104,10 @@ const TrainingHistory = ({ teamId }) => {
                             {sessionResults.map(result => (
                                 <tr key={result.id}>
                                     <td style={{ padding: '8px', borderBottom: '1px solid #ddd' }}>
-                                        {result.player.name} {result.player.surname}
+                                        {result.player ? `${result.player.name} ${result.player.surname}` : 'Unknown Player'}
                                     </td>
                                     <td style={{ padding: '8px', borderBottom: '1px solid #ddd' }}>
-                                        {Math.round(result.attendanceRate * 100)}%
+                                        {result.attendanceRate ? Math.round(result.attendanceRate * 100) : 0}%
                                     </td>
                                     <td style={{ padding: '8px', borderBottom: '1px solid #ddd' }}>
                                         <span style={{ color: getPerformanceColor(result.performance), fontWeight: 'bold' }}>
@@ -113,10 +115,10 @@ const TrainingHistory = ({ teamId }) => {
                                         </span>
                                     </td>
                                     <td style={{ padding: '8px', borderBottom: '1px solid #ddd' }}>
-                                        +{result.improvementGained.toFixed(4)}
+                                        +{result.improvementGained ? result.improvementGained.toFixed(4) : '0.0000'}
                                     </td>
                                     <td style={{ padding: '8px', borderBottom: '1px solid #ddd' }}>
-                                        -{result.fatigueGained.toFixed(2)}
+                                        -{result.fatigueGained ? result.fatigueGained.toFixed(2) : '0.00'}
                                     </td>
                                 </tr>
                             ))}

--- a/fm-web/src/components/TrainingPlan.js
+++ b/fm-web/src/components/TrainingPlan.js
@@ -31,9 +31,10 @@ const TrainingPlan = ({ teamId }) => {
     const loadTrainingPlan = async () => {
         try {
             const response = await getTrainingPlan(teamId);
-            setPlan(response.data);
+            setPlan(response.data || null);
         } catch (error) {
             console.error('Error loading training plan:', error);
+            setPlan(null);
         } finally {
             setLoading(false);
         }
@@ -54,6 +55,7 @@ const TrainingPlan = ({ teamId }) => {
     };
 
     const handleFocusChange = (day, focus) => {
+        if (!plan) return;
         setPlan(prev => ({
             ...prev,
             [day + 'Focus']: focus

--- a/fm-web/src/pages/Team.js
+++ b/fm-web/src/pages/Team.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import api, { getClub } from '../services/api';
 import Layout from '../components/Layout';
 import useSortableData from '../hooks/useSortableData';
@@ -9,6 +9,24 @@ import TrainingHistory from '../components/TrainingHistory';
 import StaffManagement from '../components/StaffManagement';
 import ConfirmationModal from '../components/ConfirmationModal';
 
+const PLAYER_ROLES = {
+  GOALKEEPER: 0,
+  DEFENDER: 1,
+  WINGBACK: 2,
+  MIDFIELDER: 3,
+  WING: 4,
+  FORWARD: 5
+};
+
+const ROLE_NAMES = {
+  [PLAYER_ROLES.GOALKEEPER]: 'GK',
+  [PLAYER_ROLES.DEFENDER]: 'DEF',
+  [PLAYER_ROLES.WINGBACK]: 'WB',
+  [PLAYER_ROLES.MIDFIELDER]: 'MID',
+  [PLAYER_ROLES.WING]: 'WNG',
+  [PLAYER_ROLES.FORWARD]: 'FWD'
+};
+
 const Team = () => {
   const [players, setPlayers] = useState([]);
   const [teamId, setTeamId] = useState(null);
@@ -16,6 +34,7 @@ const Team = () => {
   const [showModal, setShowModal] = useState(false);
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const { items: sortedPlayers, requestSort, sortConfig } = useSortableData(players);
+  const navigate = useNavigate();
 
   const user = JSON.parse(localStorage.getItem('user'));
   const clubId = user ? user.clubId : null;
@@ -64,6 +83,19 @@ const Team = () => {
     }
   };
 
+  const getPlayerRoleName = (player) => {
+    if (!player || !player.role) return '';
+    let roleKey = '';
+    if (typeof player.role === 'object') roleKey = player.role.name;
+    else if (typeof player.role === 'string') roleKey = player.role;
+    else if (typeof player.role === 'number') return ROLE_NAMES[player.role];
+
+    if (roleKey && PLAYER_ROLES[roleKey] !== undefined) {
+      return ROLE_NAMES[PLAYER_ROLES[roleKey]];
+    }
+    return roleKey || '';
+  };
+
   return (
     <Layout>
       <h1 className="mt-2">Team</h1>
@@ -106,10 +138,9 @@ const Team = () => {
       {activeTab === 'squad' && (
           <>
             {clubId && <InjuryList clubId={clubId} />}
-            <table className="table table-striped">
+            <table className="table table-striped table-hover">
                 <thead>
                 <tr>
-                    <th>Action</th>
                     <th onClick={() => requestSort('role')} style={{cursor: 'pointer'}}>Role</th>
                     <th onClick={() => requestSort('name')} style={{cursor: 'pointer'}}>Name</th>
                     <th onClick={() => requestSort('surname')} style={{cursor: 'pointer'}}>Surname</th>
@@ -121,29 +152,28 @@ const Team = () => {
                     <th onClick={() => requestSort('passing')} style={{cursor: 'pointer'}}>Passing</th>
                     <th onClick={() => requestSort('defending')} style={{cursor: 'pointer'}}>Defending</th>
                     <th onClick={() => requestSort('condition')} style={{cursor: 'pointer'}}>Condition</th>
+                    <th>Action</th>
                 </tr>
                 </thead>
                 <tbody>
                 {sortedPlayers.map(p => (
-                    <tr key={p.id}>
-                    <td>
-                        <button className="btn btn-icon" onClick={() => handlePutOnSale(p)} title="Put on sale">
-                            <i className="fa fa-exchange-alt"></i>
-                        </button>
-                    </td>
-                    <td>{p.role}</td>
-                    <td>{p.name}</td>
-                    <td>
-                        <Link to={'/player/' + p.id}>{p.surname}</Link>
-                    </td>
-                    <td>{p.age}</td>
-                    <td>{Math.round(p.stamina)}</td>
-                    <td>{Math.round(p.playmaking)}</td>
-                    <td>{Math.round(p.scoring)}</td>
-                    <td>{Math.round(p.winger)}</td>
-                    <td>{Math.round(p.passing)}</td>
-                    <td>{Math.round(p.defending)}</td>
-                    <td>{Math.round(p.condition)}</td>
+                    <tr key={p.id} onClick={() => navigate('/player/' + p.id)} style={{ cursor: 'pointer' }}>
+                        <td>{getPlayerRoleName(p)}</td>
+                        <td>{p.name}</td>
+                        <td>{p.surname}</td>
+                        <td>{p.age}</td>
+                        <td>{Math.round(p.stamina)}</td>
+                        <td>{Math.round(p.playmaking)}</td>
+                        <td>{Math.round(p.scoring)}</td>
+                        <td>{Math.round(p.winger)}</td>
+                        <td>{Math.round(p.passing)}</td>
+                        <td>{Math.round(p.defending)}</td>
+                        <td>{p.condition !== null && p.condition !== undefined ? Math.round(p.condition) : '-'}</td>
+                        <td onClick={(e) => e.stopPropagation()}>
+                            <button className="btn btn-icon" onClick={() => handlePutOnSale(p)} title="Put on sale">
+                                <i className="fa fa-exchange-alt"></i>
+                            </button>
+                        </td>
                     </tr>
                 ))}
                 </tbody>


### PR DESCRIPTION
This PR addresses UI improvements on the Team page requested by the user. It abbreviates player roles, improves table navigation by making rows clickable, and reorders columns. It also fixes stability issues in the Training and Training History tabs by handling potential null data or API response format variations gracefully. Verified with Playwright screenshots.

---
*PR created automatically by Jules for task [11903985572415960246](https://jules.google.com/task/11903985572415960246) started by @lollito*