### PR TITLE
Add getById endpoint to ClubController

### DIFF
--- a/src/main/java/com/lollito/fm/controller/rest/ClubController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/ClubController.java
@@ -35,6 +35,11 @@ public class ClubController {
     public Long count() {
         return clubService.getCount();
     }
+
+	@RequestMapping(value = "/{id}", method = RequestMethod.GET)
+    public ClubDTO getById(@PathVariable (value = "id") Long id) {
+        return clubMapper.toDto(clubService.findById(id));
+    }
 	
 	@RequestMapping(value = "/findTopByLeagueCountry/{countryId}", method = RequestMethod.GET)
     public ClubDTO findTopByLeagueCountry(@PathVariable (value = "countryId") Long countryId) {

--- a/src/test/java/com/lollito/fm/controller/rest/ClubControllerTest.java
+++ b/src/test/java/com/lollito/fm/controller/rest/ClubControllerTest.java
@@ -1,0 +1,71 @@
+package com.lollito.fm.controller.rest;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.lollito.fm.service.ClubService;
+import com.lollito.fm.service.UserService;
+import com.lollito.fm.repository.rest.CountryRepository;
+import com.lollito.fm.mapper.ClubMapper;
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.dto.ClubDTO;
+
+@WebMvcTest(controllers = ClubController.class)
+public class ClubControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ClubService clubService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private CountryRepository countryRepository;
+
+    @MockBean
+    private ClubMapper clubMapper;
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @WithMockUser(username = "lollito")
+    public void testGetClubById() throws Exception {
+        Club club = new Club();
+        club.setId(1L);
+        club.setName("Test Club");
+
+        ClubDTO clubDTO = new ClubDTO();
+        clubDTO.setId(1L);
+        clubDTO.setName("Test Club");
+
+        when(clubService.findById(1L)).thenReturn(club);
+        when(clubMapper.toDto(club)).thenReturn(clubDTO);
+
+        mockMvc.perform(get("/api/club/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.id").value(1))
+               .andExpect(jsonPath("$.name").value("Test Club"));
+    }
+}


### PR DESCRIPTION
Implemented `GET /api/club/{id}` in `ClubController` to resolve `NoResourceFoundException`. Added `ClubControllerTest` using `@WebMvcTest` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [7536746765258549817](https://jules.google.com/task/7536746765258549817) started by @lollito*