### PR TITLE
Clean ServerService creation logic and add test

### DIFF
--- a/src/main/java/com/lollito/fm/service/ServerService.java
+++ b/src/main/java/com/lollito/fm/service/ServerService.java
@@ -46,7 +46,6 @@ public class ServerService {
 		Server server = new Server();
 		server.setName(serverName);
 		server.setOwner(userService.getLoggedUser());
-//		LocalDate gameStartDate = LocalDate.of(2020, Month.AUGUST, 21);
 		LocalDateTime gameStartDate = LocalDateTime.now();
 		for(Country country : countryService.findByCreateLeague(true)){
 			League league = new League();
@@ -54,7 +53,6 @@ public class ServerService {
 			league.setCountry(country);
             league.setServer(server); // Explicitly set server
 			server.addLeague(league);
-			// Pass server instead of game (assuming ClubService signature will be updated)
 			List<Club> clubs = clubService.createClubs(server, league, 10);
 			league.setClubs(clubs);
 			league.setCurrentSeason(seasonService.create(league, gameStartDate));
@@ -62,7 +60,6 @@ public class ServerService {
 		
 		server.setCurrentDate(gameStartDate);
 		server = serverRepository.save(server);
-//		sessionBean.setGameId(game.getId());
 		return server;
 	}
 	
@@ -109,7 +106,6 @@ public class ServerService {
 	public ServerResponse load(){
 		ServerResponse serverResponse = new ServerResponse();
 		//FIXME
-//		Game game = sessionBean.getGame();
 		Server server = new Server();
 		serverResponse.setCurrentDate(server.getCurrentDate());
 		return serverResponse;
@@ -122,7 +118,6 @@ public class ServerService {
 			//TODO error
 			logger.error("error - server is null");
 		} else {
-//			sessionBean.setGameId(gameId);
 			serverResponse.setCurrentDate(server.getCurrentDate());
 		}
 		return serverResponse;

--- a/src/test/java/com/lollito/fm/service/ServerServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ServerServiceTest.java
@@ -1,10 +1,14 @@
 package com.lollito.fm.service;
 
 import static org.mockito.Mockito.verify;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,11 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.lollito.fm.repository.rest.ServerRepository;
 
-import org.springframework.security.access.AccessDeniedException;
-
-import com.lollito.fm.model.AdminRole;
 import com.lollito.fm.model.Server;
 import com.lollito.fm.model.User;
+import com.lollito.fm.model.Country;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.Season;
 
 @ExtendWith(MockitoExtension.class)
 class ServerServiceTest {
@@ -29,6 +33,18 @@ class ServerServiceTest {
     @Mock
     private UserService userService;
 
+    @Mock
+    private CountryService countryService;
+
+    @Mock
+    private ClubService clubService;
+
+    @Mock
+    private SeasonService seasonService;
+
+    @Mock
+    private LeagueService leagueService;
+
     @InjectMocks
     private ServerService serverService;
 
@@ -36,5 +52,39 @@ class ServerServiceTest {
     void testDeleteAll() {
         serverService.deleteAll();
         verify(serverRepository).deleteAll();
+    }
+
+    @Test
+    void testCreate() {
+        String serverName = "Test Server";
+        User user = new User();
+        user.setUsername("owner");
+
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        Country country = new Country();
+        country.setName("Test Country");
+        when(countryService.findByCreateLeague(true)).thenReturn(Collections.singletonList(country));
+
+        when(clubService.createClubs(any(Server.class), any(League.class), eq(10))).thenReturn(new ArrayList<>());
+
+        when(seasonService.create(any(League.class), any(LocalDateTime.class))).thenReturn(new Season());
+
+        when(serverRepository.save(any(Server.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        Server result = serverService.create(serverName);
+
+        assertNotNull(result);
+        assertEquals(serverName, result.getName());
+        assertEquals(user, result.getOwner());
+        assertNotNull(result.getCurrentDate());
+        // Allow a small time difference
+        assertTrue(result.getCurrentDate().isBefore(LocalDateTime.now().plusSeconds(1)));
+        assertTrue(result.getCurrentDate().isAfter(LocalDateTime.now().minusSeconds(10)));
+
+        verify(countryService).findByCreateLeague(true);
+        verify(clubService).createClubs(eq(result), any(League.class), eq(10));
+        verify(seasonService).create(any(League.class), eq(result.getCurrentDate()));
+        verify(serverRepository).save(result);
     }
 }


### PR DESCRIPTION
This PR cleans up `ServerService` by removing legacy commented-out code related to `Game` entity and `sessionBean` which are no longer used. It also adds a comprehensive unit test for the `create` method in `ServerServiceTest` to ensure the server creation logic is correct and robust, utilizing mockito to mock dependencies.

---
*PR created automatically by Jules for task [14452292066992997201](https://jules.google.com/task/14452292066992997201) started by @lollito*