### PR TITLE
Fix ServerService load logic and add tests

### DIFF
--- a/src/main/java/com/lollito/fm/service/ServerService.java
+++ b/src/main/java/com/lollito/fm/service/ServerService.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.EntityNotFoundException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,25 +108,22 @@ public class ServerService {
 		return serverResponse;
 	}
 	
-	public ServerResponse load(){
-		ServerResponse serverResponse = new ServerResponse();
-		//FIXME
-//		Game game = sessionBean.getGame();
-		Server server = new Server();
-		serverResponse.setCurrentDate(server.getCurrentDate());
-		return serverResponse;
+	public ServerResponse load() {
+		User user = userService.getLoggedUser();
+		if (user != null && user.getServer() != null) {
+			ServerResponse serverResponse = new ServerResponse();
+			serverResponse.setCurrentDate(user.getServer().getCurrentDate());
+			return serverResponse;
+		}
+		throw new EntityNotFoundException("User not assigned to any server");
 	}
 	
-	public ServerResponse load(Long serverId){
-		Server server = serverRepository.findById(serverId).get();
+	public ServerResponse load(Long serverId) {
+		Server server = serverRepository.findById(serverId)
+				.orElseThrow(() -> new EntityNotFoundException("Server not found"));
+
 		ServerResponse serverResponse = new ServerResponse();
-		if (server == null){
-			//TODO error
-			logger.error("error - server is null");
-		} else {
-//			sessionBean.setGameId(gameId);
-			serverResponse.setCurrentDate(server.getCurrentDate());
-		}
+		serverResponse.setCurrentDate(server.getCurrentDate());
 		return serverResponse;
 	}
 	

--- a/src/test/java/com/lollito/fm/service/ServerServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ServerServiceTest.java
@@ -1,10 +1,15 @@
 package com.lollito.fm.service;
 
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+
+import jakarta.persistence.EntityNotFoundException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,13 +17,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.lollito.fm.repository.rest.ServerRepository;
-
-import org.springframework.security.access.AccessDeniedException;
-
-import com.lollito.fm.model.AdminRole;
 import com.lollito.fm.model.Server;
 import com.lollito.fm.model.User;
+import com.lollito.fm.model.rest.ServerResponse;
+import com.lollito.fm.repository.rest.ServerRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ServerServiceTest {
@@ -36,5 +38,55 @@ class ServerServiceTest {
     void testDeleteAll() {
         serverService.deleteAll();
         verify(serverRepository).deleteAll();
+    }
+
+    @Test
+    void testLoadById_Success() {
+        Long serverId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        Server server = new Server();
+        server.setId(serverId);
+        server.setCurrentDate(now);
+
+        when(serverRepository.findById(serverId)).thenReturn(Optional.of(server));
+
+        ServerResponse response = serverService.load(serverId);
+
+        assertNotNull(response);
+        assertEquals(now, response.getCurrentDate());
+    }
+
+    @Test
+    void testLoadById_NotFound() {
+        Long serverId = 1L;
+        when(serverRepository.findById(serverId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> serverService.load(serverId));
+    }
+
+    @Test
+    void testLoadCurrent_Success() {
+        User user = new User();
+        Server server = new Server();
+        LocalDateTime now = LocalDateTime.now();
+        server.setCurrentDate(now);
+        user.setServer(server);
+
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        ServerResponse response = serverService.load();
+
+        assertNotNull(response);
+        assertEquals(now, response.getCurrentDate());
+    }
+
+    @Test
+    void testLoadCurrent_NoServer() {
+        User user = new User();
+        user.setServer(null);
+
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        assertThrows(EntityNotFoundException.class, () -> serverService.load());
     }
 }


### PR DESCRIPTION
Fixed `ServerService.load(Long)` to correctly throw `EntityNotFoundException` instead of calling `.get()` on an empty Optional.
Implemented `ServerService.load()` to return the server associated with the currently logged-in user, or throw `EntityNotFoundException` if no server is assigned.
Added comprehensive unit tests for both methods in `ServerServiceTest` covering success and failure scenarios.

---
*PR created automatically by Jules for task [2008200432148218310](https://jules.google.com/task/2008200432148218310) started by @lollito*