### PR TITLE
Secure WebSocket Notifications

### DIFF
--- a/fm-web/src/components/Navbar.js
+++ b/fm-web/src/components/Navbar.js
@@ -48,11 +48,11 @@ const Navbar = ({ onToggleMenu }) => {
   useEffect(() => {
       if (!user) return;
 
-      const socket = new SockJS(API_BASE_URL + '/ws/live-match');
+      const socket = new SockJS(API_BASE_URL + '/ws/live-match?token=' + user.accessToken);
       stompClient.current = new Client({
           webSocketFactory: () => socket,
           onConnect: () => {
-              stompClient.current.subscribe('/topic/user/' + user.id + '/notifications', (message) => {
+              stompClient.current.subscribe('/user/queue/notifications', (message) => {
                   const notif = JSON.parse(message.body);
                   if (notif.type === 'MATCH_STARTED') {
                       setNotification(notif);

--- a/src/main/java/com/lollito/fm/config/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/com/lollito/fm/config/security/jwt/AuthTokenFilter.java
@@ -59,6 +59,11 @@ public class AuthTokenFilter extends OncePerRequestFilter {
       return headerAuth.substring(7);
     }
 
+    String token = request.getParameter("token");
+    if (StringUtils.hasText(token)) {
+      return token;
+    }
+
     return null;
   }
 }

--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -79,9 +79,7 @@ public class MatchProcessor {
 
     private void notifyUser(User user, Long matchId) {
         if (user != null) {
-            // Using a public topic because WebSocket connections are currently unauthenticated (whitelisted).
-            // TODO: Secure this by implementing WebSocket authentication and switching back to convertAndSendToUser.
-            messagingTemplate.convertAndSend("/topic/user/" + user.getId() + "/notifications",
+            messagingTemplate.convertAndSendToUser(user.getUsername(), "/queue/notifications",
                 new NotificationDTO("MATCH_STARTED", matchId, "Match Started!"));
         }
     }

--- a/src/test/java/com/lollito/fm/service/MatchProcessorTest.java
+++ b/src/test/java/com/lollito/fm/service/MatchProcessorTest.java
@@ -1,0 +1,100 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.mapper.MatchMapper;
+import com.lollito.fm.mapper.MatchPlayerStatsMapper;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.MatchStatus;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.rest.MatchRepository;
+import com.lollito.fm.repository.rest.SeasonRepository;
+import com.lollito.fm.service.MatchProcessor.NotificationDTO;
+
+@ExtendWith(MockitoExtension.class)
+class MatchProcessorTest {
+
+    @Mock private MatchRepository matchRepository;
+    @Mock private SimulationMatchService simulationMatchService;
+    @Mock private SeasonService seasonService;
+    @Mock private LeagueService leagueService;
+    @Mock private SeasonRepository seasonRepository;
+    @Mock private LiveMatchService liveMatchService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private MatchMapper matchMapper;
+    @Mock private MatchPlayerStatsMapper matchPlayerStatsMapper;
+    @Mock private PlayerService playerService;
+    @Mock private PlayerHistoryService playerHistoryService;
+    @Mock private RankingService rankingService;
+
+    @InjectMocks
+    private MatchProcessor matchProcessor;
+
+    private Match match;
+    private User homeUser;
+    private User awayUser;
+
+    @BeforeEach
+    void setUp() {
+        homeUser = new User();
+        homeUser.setId(10L);
+        homeUser.setUsername("homeUser");
+
+        awayUser = new User();
+        awayUser.setId(20L);
+        awayUser.setUsername("awayUser");
+
+        Club home = new Club();
+        home.setId(1L);
+        home.setName("Home FC");
+        home.setUser(homeUser);
+
+        Club away = new Club();
+        away.setId(2L);
+        away.setName("Away FC");
+        away.setUser(awayUser);
+
+        match = new Match();
+        match.setId(100L);
+        match.setHome(home);
+        match.setAway(away);
+        match.setStatus(MatchStatus.SCHEDULED);
+    }
+
+    @Test
+    void testProcessMatchNotifiesUsers() {
+        when(matchRepository.findById(100L)).thenReturn(Optional.of(match));
+
+        matchProcessor.processMatch(100L);
+
+        // Verify simulation call
+        verify(simulationMatchService).simulate(eq(match), any(), eq(false));
+
+        // Verify notifications sent to users via user-specific destination
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("homeUser"),
+                eq("/queue/notifications"),
+                any(NotificationDTO.class));
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("awayUser"),
+                eq("/queue/notifications"),
+                any(NotificationDTO.class));
+    }
+}


### PR DESCRIPTION
This PR secures the WebSocket notification system. 

Previously, user notifications were broadcast to public topics (`/topic/user/{id}/notifications`), which allowed any connected client to listen to any user's notifications.

This change:
1.  Enables WebSocket authentication by allowing the `AuthTokenFilter` to read the JWT from a `token` query parameter (standard for SockJS/WebSocket where headers are restricted).
2.  Updates `MatchProcessor` to send notifications to a user-specific destination (`/user/queue/notifications`) using `messagingTemplate.convertAndSendToUser`. This ensures messages are routed only to the authenticated session of the target user.
3.  Updates the frontend (`Navbar.js`) to include the access token in the SockJS connection URL and subscribe to the standard user queue alias.
4.  Adds unit tests for `MatchProcessor` to verify the new notification routing logic.


---
*PR created automatically by Jules for task [9694174506064100551](https://jules.google.com/task/9694174506064100551) started by @lollito*