### PR TITLE
Make teams clickable and highlight human managers

### DIFF
--- a/fm-web/src/components/TeamLink.js
+++ b/fm-web/src/components/TeamLink.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const TeamLink = ({ club, style, className }) => {
+  if (!club) return null;
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <Link
+      to={`/team/${club.teamId}`}
+      onClick={handleClick}
+      className={className}
+      style={{ textDecoration: 'none', color: 'inherit', ...style }}
+    >
+      {club.name}
+      {club.isHuman && (
+        <i
+          className="fas fa-user-circle text-primary"
+          style={{ marginLeft: '6px' }}
+          title="Human Manager"
+        />
+      )}
+    </Link>
+  );
+};
+
+export default TeamLink;

--- a/fm-web/src/pages/LiveMatches.js
+++ b/fm-web/src/pages/LiveMatches.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
 import Layout from '../components/Layout';
+import TeamLink from '../components/TeamLink';
 
 const LiveMatches = () => {
   const [liveMatches, setLiveMatches] = useState([]);
@@ -79,7 +80,7 @@ const LiveMatches = () => {
                                   ) : (
                                     <i className="fas fa-shield-alt text-muted mr-2"></i>
                                   )}
-                                  <strong>{match.home.name}</strong>
+                                  <strong><TeamLink club={match.home} /></strong>
                                 </div>
                               </td>
                               <td className="align-middle font-weight-bold h5">
@@ -92,7 +93,7 @@ const LiveMatches = () => {
                                   ) : (
                                     <i className="fas fa-shield-alt text-muted mr-2"></i>
                                   )}
-                                  <strong>{match.away.name}</strong>
+                                  <strong><TeamLink club={match.away} /></strong>
                                 </div>
                               </td>
                               <td className="align-middle text-muted">{match.stadiumName}</td>

--- a/fm-web/src/pages/MatchDetail.js
+++ b/fm-web/src/pages/MatchDetail.js
@@ -4,6 +4,7 @@ import api from '../services/api';
 import Layout from '../components/Layout';
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, ResponsiveContainer, Legend } from 'recharts';
 import useSortableData from '../hooks/useSortableData';
+import TeamLink from '../components/TeamLink';
 
 const MatchDetail = () => {
     const { id } = useParams();
@@ -98,13 +99,13 @@ const MatchDetail = () => {
                 <div className="card-body">
                     <div className="row align-items-center">
                         <div className="col">
-                            <h3>{match.home.name}</h3>
+                            <h3><TeamLink club={match.home} /></h3>
                         </div>
                         <div className="col-auto">
                             <h1 style={{ fontSize: '3.5rem', margin: '0 20px' }}>{match.homeScore} - {match.awayScore}</h1>
                         </div>
                         <div className="col">
-                            <h3>{match.away.name}</h3>
+                            <h3><TeamLink club={match.away} /></h3>
                         </div>
                     </div>
                     <div className="text-muted mt-2">

--- a/fm-web/src/pages/Ranking.js
+++ b/fm-web/src/pages/Ranking.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import api from '../services/api';
 import Layout from '../components/Layout';
 import useSortableData from '../hooks/useSortableData';
+import TeamLink from '../components/TeamLink';
 
 const Ranking = () => {
   const [ranking, setRanking] = useState([]);
@@ -49,7 +50,7 @@ const Ranking = () => {
           {sortedRanking.map((r, i) => (
             <tr key={i}>
               <td>{i + 1}</td>
-              <td>{r.club.name}</td>
+              <td><TeamLink club={r.club} /></td>
               <td>{r.played}</td>
               <td>{r.won}</td>
               <td>{r.drawn}</td>

--- a/fm-web/src/pages/Schedule.js
+++ b/fm-web/src/pages/Schedule.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
 import Layout from '../components/Layout';
+import TeamLink from '../components/TeamLink';
 
 const Schedule = () => {
   const [schedule, setSchedule] = useState([]);
@@ -76,7 +77,7 @@ const Schedule = () => {
                             fontWeight: homeBold ? 'bold' : 'normal'
                           }}
                         >
-                          {match.home.name}
+                          <TeamLink club={match.home} />
                         </td>
                         <td style={{ textAlign: 'center' }}>
                           {isPlayed ? `${match.homeScore} - ${match.awayScore}` : '-'}
@@ -88,7 +89,7 @@ const Schedule = () => {
                             fontWeight: awayBold ? 'bold' : 'normal'
                           }}
                         >
-                          {match.away.name}
+                          <TeamLink club={match.away} />
                         </td>
                       </tr>
                     );

--- a/src/main/java/com/lollito/fm/mapper/ClubMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/ClubMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.Mapping;
 public interface ClubMapper {
     @Mapping(source = "league.id", target = "leagueId")
     @Mapping(source = "team.id", target = "teamId")
+    @Mapping(target = "isHuman", expression = "java(club.getUser() != null)")
     ClubDTO toDto(Club club);
     Club toEntity(ClubDTO dto);
 }

--- a/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
@@ -18,4 +18,5 @@ public class ClubDTO {
     private String logoURL;
     private Long leagueId;
     private Long teamId;
+    private Boolean isHuman;
 }


### PR DESCRIPTION
Implemented the requested feature to make team names clickable across the application and highlight teams managed by registered users.

Changes:
1.  **Backend**:
    *   Modified `ClubDTO` to include `isHuman` boolean.
    *   Updated `ClubMapper` to set `isHuman` to true if `club.getUser()` is not null.

2.  **Frontend**:
    *   Created `fm-web/src/components/TeamLink.js`: A reusable component that renders a link to `/team/:teamId`. It prevents event propagation (useful for table rows) and displays a `fa-user-circle` icon if `isHuman` is true.
    *   Updated `Ranking.js` (Standings) to use `TeamLink`.
    *   Updated `Schedule.js` to use `TeamLink`.
    *   Updated `LiveMatches.js` to use `TeamLink`.
    *   Updated `MatchDetail.js` to use `TeamLink`.

Verified with Playwright script (mocking the API) that the link works and the icon appears for human teams. Backend build passed.

---
*PR created automatically by Jules for task [411969512301628315](https://jules.google.com/task/411969512301628315) started by @lollito*