### PR TITLE
Fix infinite recursion in Player JSON serialization

### DIFF
--- a/src/main/java/com/lollito/fm/model/Contract.java
+++ b/src/main/java/com/lollito/fm/model/Contract.java
@@ -20,6 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,6 +40,7 @@ public class Contract {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
+    @JsonIgnore
     private Player player;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/lollito/fm/model/ContractNegotiation.java
+++ b/src/main/java/com/lollito/fm/model/ContractNegotiation.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -36,6 +38,7 @@ public class ContractNegotiation {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
+    @JsonIgnore
     private Player player;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/lollito/fm/model/Injury.java
+++ b/src/main/java/com/lollito/fm/model/Injury.java
@@ -2,6 +2,8 @@ package com.lollito.fm.model;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -36,6 +38,7 @@ public class Injury {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     @ToString.Exclude
+    @JsonIgnore
     private Player player;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lollito/fm/model/PlayerAchievement.java
+++ b/src/main/java/com/lollito/fm/model/PlayerAchievement.java
@@ -3,6 +3,8 @@ package com.lollito.fm.model;
 import java.io.Serializable;
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -45,6 +47,7 @@ public class PlayerAchievement implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     @ToString.Exclude
+    @JsonIgnore
     private Player player;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lollito/fm/model/PlayerCareerStats.java
+++ b/src/main/java/com/lollito/fm/model/PlayerCareerStats.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -48,6 +50,7 @@ public class PlayerCareerStats implements Serializable {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     @ToString.Exclude
+    @JsonIgnore
     private Player player;
 
     // Career totals

--- a/src/main/java/com/lollito/fm/model/PlayerSeasonStats.java
+++ b/src/main/java/com/lollito/fm/model/PlayerSeasonStats.java
@@ -1,6 +1,7 @@
 package com.lollito.fm.model;
 
 import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -41,21 +42,25 @@ public class PlayerSeasonStats implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     @ToString.Exclude
+    @JsonIgnore
     private Player player;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "season_id")
     @ToString.Exclude
+    @JsonIgnore
     private Season season;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     @ToString.Exclude
+    @JsonIgnore
     private Club club;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "league_id")
     @ToString.Exclude
+    @JsonIgnore
     private League league;
 
     // Match statistics

--- a/src/main/java/com/lollito/fm/model/PlayerTransferHistory.java
+++ b/src/main/java/com/lollito/fm/model/PlayerTransferHistory.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -46,6 +48,7 @@ public class PlayerTransferHistory implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     @ToString.Exclude
+    @JsonIgnore
     private Player player;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/lollito/fm/model/Season.java
+++ b/src/main/java/com/lollito/fm/model/Season.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -58,6 +60,7 @@ public class Season implements Serializable{
 	@OneToMany(mappedBy = "season", cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
 	@Builder.Default
 	@ToString.Exclude
+	@JsonIgnore
 	private List<Round> rounds = new ArrayList<>();
 	
 	@ManyToOne( fetch = FetchType.LAZY  )
@@ -69,6 +72,7 @@ public class Season implements Serializable{
 	@OrderBy("points desc")
 	@Builder.Default
 	@ToString.Exclude
+	@JsonIgnore
 	private List<Ranking> rankingLines = new ArrayList<>();
 	
 	@Builder.Default


### PR DESCRIPTION
Resolved `HttpMessageNotWritableException` caused by infinite recursion and excessive nesting depth during JSON serialization of `Player` and related entities.

Changes:
- Added `@JsonIgnore` to `player`, `club`, `league`, and `season` fields in `PlayerSeasonStats.java`.
- Added `@JsonIgnore` to `player` field in `PlayerTransferHistory.java`.
- Added `@JsonIgnore` to `player` field in `PlayerAchievement.java`.
- Added `@JsonIgnore` to `player` field in `PlayerCareerStats.java`.
- Added `@JsonIgnore` to `player` field in `Injury.java`.
- Added `@JsonIgnore` to `player` field in `Contract.java`.
- Added `@JsonIgnore` to `player` field in `ContractNegotiation.java`.
- Added `@JsonIgnore` to `rounds` and `rankingLines` fields in `Season.java`.

These changes break the circular references and limit the object graph traversal depth, ensuring successful JSON serialization.

---
*PR created automatically by Jules for task [11265929411544557584](https://jules.google.com/task/11265929411544557584) started by @lollito*