### PR TITLE
Match Notification Persistence and Animation

### DIFF
--- a/fm-web/src/components/Navbar.js
+++ b/fm-web/src/components/Navbar.js
@@ -56,7 +56,8 @@ const Navbar = ({ onToggleMenu }) => {
                   const notif = JSON.parse(message.body);
                   if (notif.type === 'MATCH_STARTED') {
                       setNotification(notif);
-                      setTimeout(() => setNotification(null), 10000); // Hide after 10s
+                  } else if (notif.type === 'MATCH_ENDED') {
+                      setNotification(prev => (prev && prev.matchId === notif.matchId) ? null : prev);
                   }
               });
           },
@@ -155,7 +156,7 @@ const Navbar = ({ onToggleMenu }) => {
             setNotification(null);
         }}>
             <div className="notification-content">
-                <i className="fas fa-futbol"></i>
+                <i className="fas fa-futbol bouncing-ball"></i>
                 <span>{notification.message}</span>
             </div>
         </div>

--- a/fm-web/src/styles/Navbar.css
+++ b/fm-web/src/styles/Navbar.css
@@ -251,3 +251,12 @@
   from { transform: translateX(100%); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
 }
+
+@keyframes bounce {
+  from { transform: translateY(0); }
+  to { transform: translateY(-10px); }
+}
+
+.bouncing-ball {
+  animation: bounce 0.6s infinite alternate;
+}

--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -73,14 +73,14 @@ public class MatchProcessor {
         matchRepository.saveAndFlush(match);
 
         // Notify users
-        notifyUser(match.getHome().getUser(), match.getId());
-        notifyUser(match.getAway().getUser(), match.getId());
+        notifyUser(match.getHome().getUser(), match.getId(), "MATCH_STARTED", "Match Started!");
+        notifyUser(match.getAway().getUser(), match.getId(), "MATCH_STARTED", "Match Started!");
     }
 
-    private void notifyUser(User user, Long matchId) {
+    private void notifyUser(User user, Long matchId, String type, String message) {
         if (user != null) {
             messagingTemplate.convertAndSendToUser(user.getUsername(), "/queue/notifications",
-                new NotificationDTO("MATCH_STARTED", matchId, "Match Started!"));
+                new NotificationDTO(type, matchId, message));
         }
     }
 
@@ -147,6 +147,10 @@ public class MatchProcessor {
 
             rankingService.update(match);
             checkRoundAndSeasonProgression(match);
+
+            // Notify users match ended
+            notifyUser(match.getHome().getUser(), match.getId(), "MATCH_ENDED", "Match Ended!");
+            notifyUser(match.getAway().getUser(), match.getId(), "MATCH_ENDED", "Match Ended!");
 
             // Cleanup session?
             // liveMatchService.deleteSession(session); // optional


### PR DESCRIPTION
This change ensures that the "Match Started" notification remains visible for the entire duration of the match, as requested. It also adds a bouncing ball animation to the football icon in the notification.

Key changes:
- Backend: `MatchProcessor.finalizeMatch` now sends a `MATCH_ENDED` notification.
- Frontend: `Navbar.js` logic updated to handle notification persistence and removal.
- Styles: Added CSS animation for the bouncing ball.

---
*PR created automatically by Jules for task [5207467654402179014](https://jules.google.com/task/5207467654402179014) started by @lollito*