### PR TITLE
🔒 Security Fix: Externalize Hardcoded JWT Secret

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       SPRING_JPA_HIBERNATE_DDL_AUTO: ${DDL_AUTO:-update}
       JAVA_OPTS: ${JAVA_OPTS:--Xmx1g -Xms512m}
       SERVER_PORT: 8080
+      FM_APP_JWT_SECRET: ${JWT_SECRET}
     ports:
       - "8080:8080"
     volumes:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,7 +40,7 @@ de.flapdoodle.mongodb.embedded.version=4.0.25
 #spring.data.rest.base-path=/api
 #spring.data.rest.defaultMediaType=application/json
 
-fm.app.jwtSecret=fmSecretKeyForFootballManagerProject2026DecoupledArchitecture
+fm.app.jwtSecret=${FM_APP_JWT_SECRET}
 fm.app.jwtExpirationMs=86400000
 
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false

--- a/src/test/java/com/lollito/fm/config/security/jwt/JwtUtilsTest.java
+++ b/src/test/java/com/lollito/fm/config/security/jwt/JwtUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class JwtUtilsTest {
 
     private JwtUtils jwtUtils;
-    private String secret = "fmSecretKeyForFootballManagerProject2026DecoupledArchitecture";
+    private String secret = "testSecretKeyForIntegrationTestingOnly";
 
     @BeforeEach
     void setUp() {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,7 +7,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 spring.main.allow-circular-references=true
 
-fm.app.jwtSecret=fmSecretKeyForFootballManagerProject2026DecoupledArchitecture
+fm.app.jwtSecret=testSecretKeyForIntegrationTestingOnly
 fm.app.jwtExpirationMs=86400000
 
 grandstand.capacity.0=0


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded JWT secret in `src/main/resources/application.properties` with an environment variable injection (`${FM_APP_JWT_SECRET}`).

⚠️ **Risk:** The previous configuration exposed the production JWT secret directly in the source code, allowing anyone with access to the repository to forge valid authentication tokens and compromise the system.

🛡️ **Solution:**
- Modified `application.properties` to read the secret from the `FM_APP_JWT_SECRET` environment variable.
- Updated `docker-compose.yml` to inject this variable into the backend container.
- Updated test configuration (`src/test/resources/application.properties` and `JwtUtilsTest`) to use a dedicated, generic test key, ensuring tests pass without relying on production secrets.

---
*PR created automatically by Jules for task [16889712601603461391](https://jules.google.com/task/16889712601603461391) started by @lollito*