### PR TITLE
🧪 Add tests for ClubService batch creation

### DIFF
--- a/src/test/java/com/lollito/fm/service/ClubServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ClubServiceTest.java
@@ -1,0 +1,92 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.Server;
+import com.lollito.fm.model.Team;
+import com.lollito.fm.repository.rest.ClubRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceTest {
+
+	@Mock
+	private TeamService teamService;
+
+	@Mock
+	private NameService nameService;
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private ClubRepository clubRepository;
+
+	@InjectMocks
+	private ClubService clubService;
+
+	@Test
+	void testCreateClubs() {
+		// Arrange
+		Server server = new Server();
+		League league = new League();
+		int clubNumber = 5;
+		String mockClubName = "Test Club";
+		Team mockTeam = new Team();
+
+		when(nameService.generateClubName()).thenReturn(mockClubName);
+		when(teamService.createTeam()).thenReturn(mockTeam);
+
+		// Act
+		List<Club> result = clubService.createClubs(server, league, clubNumber);
+
+		// Assert
+		assertNotNull(result);
+		assertEquals(clubNumber, result.size());
+
+		for (Club club : result) {
+			assertEquals(league, club.getLeague());
+			assertEquals(mockClubName, club.getName());
+			assertEquals(mockTeam, club.getTeam());
+			assertNotNull(club.getFoundation());
+			assertNotNull(club.getLogoURL());
+			assertNotNull(club.getStadium());
+			assertNotNull(club.getFinance());
+		}
+
+		verify(nameService, times(clubNumber)).generateClubName();
+		verify(teamService, times(clubNumber)).createTeam();
+	}
+
+	@Test
+	void testCreateClubsZero() {
+		// Arrange
+		Server server = new Server();
+		League league = new League();
+		int clubNumber = 0;
+
+		// Act
+		List<Club> result = clubService.createClubs(server, league, clubNumber);
+
+		// Assert
+		assertNotNull(result);
+		assertEquals(0, result.size());
+
+		verifyNoInteractions(nameService);
+		verifyNoInteractions(teamService);
+	}
+}


### PR DESCRIPTION
This PR adds unit tests for `ClubService.createClubs` to ensure that batch club creation works as expected. It covers the happy path where multiple clubs are created and the edge case where zero clubs are requested. The tests mock all dependencies to strictly unit test the service logic.

---
*PR created automatically by Jules for task [4181809015932833516](https://jules.google.com/task/4181809015932833516) started by @lollito*