### PR TITLE
🔒 Fix sensitive data exposure in RegistrationRequest logs

### DIFF
--- a/src/main/java/com/lollito/fm/model/rest/RegistrationRequest.java
+++ b/src/main/java/com/lollito/fm/model/rest/RegistrationRequest.java
@@ -143,10 +143,6 @@ public class RegistrationRequest implements Serializable{
 		builder.append(email);
 		builder.append(", emailConfirm=");
 		builder.append(emailConfirm);
-		builder.append(", password=");
-		builder.append(password);
-		builder.append(", passwordConfirm=");
-		builder.append(passwordConfirm);
 		builder.append(", countryId=");
 		builder.append(countryId);
 		builder.append(", clubName=");

--- a/src/test/java/com/lollito/fm/model/rest/RegistrationRequestTest.java
+++ b/src/test/java/com/lollito/fm/model/rest/RegistrationRequestTest.java
@@ -1,0 +1,29 @@
+package com.lollito.fm.model.rest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class RegistrationRequestTest {
+
+    @Test
+    public void toString_shouldNotIncludeSensitiveData() {
+        RegistrationRequest request = new RegistrationRequest();
+        request.setName("John");
+        request.setSurname("Doe");
+        request.setUsername("johndoe");
+        request.setEmail("john@example.com");
+        request.setEmailConfirm("john@example.com");
+        request.setPassword("secretPassword");
+        request.setPasswordConfirm("secretPassword");
+        request.setCountryId(1L);
+        request.setClubName("FC John");
+
+        String toStringOutput = request.toString();
+
+        assertFalse(toStringOutput.contains("password=secretPassword"), "toString should not contain password");
+        assertFalse(toStringOutput.contains("passwordConfirm=secretPassword"), "toString should not contain passwordConfirm");
+        assertTrue(toStringOutput.contains("username=johndoe"), "toString should contain non-sensitive data like username");
+    }
+}


### PR DESCRIPTION
**Vulnerability Fixed:** Sensitive Data Exposure in Logs

**Risk:** If `RegistrationRequest` objects were logged (e.g., during debugging or error handling), plain text passwords would be written to the logs, potentially exposing user credentials to anyone with access to the logs.

**Solution:** Modified the `toString()` method in `src/main/java/com/lollito/fm/model/rest/RegistrationRequest.java` to exclude `password` and `passwordConfirm` fields. Added a unit test `src/test/java/com/lollito/fm/model/rest/RegistrationRequestTest.java` to verify the fix and prevent regression.

---
*PR created automatically by Jules for task [2517988428759924713](https://jules.google.com/task/2517988428759924713) started by @lollito*