### PR TITLE
Security: Fix missing input validation in UserController login

### DIFF
--- a/src/main/java/com/lollito/fm/controller/rest/UserController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/UserController.java
@@ -24,8 +24,10 @@ import com.lollito.fm.model.User;
 import com.lollito.fm.model.dto.UserDTO;
 import com.lollito.fm.model.rest.JwtResponse;
 import com.lollito.fm.model.rest.RegistrationRequest;
+import com.lollito.fm.model.rest.LoginRequest;
 import com.lollito.fm.service.UserService;
 import com.lollito.fm.mapper.UserMapper;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping(value="/api/user")
@@ -47,7 +49,7 @@ public class UserController {
     }
 	
 	@PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody RegistrationRequest request) {
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
 		logger.info("loginRequest {}", request);
 		Authentication authentication = authenticationManager.authenticate(
 				new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));

--- a/src/main/java/com/lollito/fm/model/rest/LoginRequest.java
+++ b/src/main/java/com/lollito/fm/model/rest/LoginRequest.java
@@ -1,0 +1,40 @@
+package com.lollito.fm.model.rest;
+
+import java.io.Serializable;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class LoginRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @NotBlank
+    @Size(min = 3, max = 15)
+    private String username;
+
+    @NotBlank
+    @Size(min = 6, max = 120)
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "LoginRequest [username=" + username + "]";
+    }
+}

--- a/src/test/java/com/lollito/fm/controller/rest/UserControllerTest.java
+++ b/src/test/java/com/lollito/fm/controller/rest/UserControllerTest.java
@@ -1,0 +1,111 @@
+package com.lollito.fm.controller.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.mapper.UserMapper;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.rest.LoginRequest;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.service.UserService;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserMapper userMapper;
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    public void testLoginSuccess() throws Exception {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("validUser");
+        request.setPassword("validPassword");
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("validUser");
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            org.springframework.security.core.userdetails.User
+                .withUsername("validUser")
+                .password("validPassword")
+                .authorities(new ArrayList<>())
+                .build(),
+            null
+        );
+
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+        when(userService.findByUsernameAndActive("validUser")).thenReturn(user);
+        when(jwtUtils.generateJwtToken(user)).thenReturn("fake-jwt-token");
+
+        mockMvc.perform(post("/api/user/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testLoginInvalidUsername() throws Exception {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("ab"); // Too short
+        request.setPassword("validPassword");
+
+        mockMvc.perform(post("/api/user/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testLoginInvalidPassword() throws Exception {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("validUser");
+        request.setPassword("12345"); // Too short
+
+        mockMvc.perform(post("/api/user/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
This PR addresses a security vulnerability where the `login` endpoint lacked input validation.

Changes:
- Created `LoginRequest` DTO in `com.lollito.fm.model.rest` with `username` and `password` fields and appropriate validation constraints.
- Updated `UserController.login` method to accept `LoginRequest` and validate it using `@Valid`.
- Added `UserControllerTest` to verify that valid requests are accepted and invalid requests are rejected with 400 Bad Request.

Risk Assessment:
- The change introduces validation constraints. To avoid regression for existing users with long passwords, the password max length is set to 120 (relaxed from `RegistrationRequest`'s 20).
- `LoginRequest` only exposes `username` in `toString()`, preventing password logging.

Testing:
- `UserControllerTest` confirms validation works as expected.
- Existing tests pass (except unrelated flaky test).

---
*PR created automatically by Jules for task [4973990436465867095](https://jules.google.com/task/4973990436465867095) started by @lollito*