### PR TITLE
⚡ Avoid redundant match save in MatchProcessor

### DIFF
--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -56,7 +56,7 @@ public class MatchProcessor {
         logger.info("Processing match {} : {} vs {}", match.getId(), match.getHome().getName(), match.getAway().getName());
 
         // Simulate to get result
-        simulationMatchService.simulate(match, null, false);
+        simulationMatchService.simulate(match, null, false, false);
 
         // Create session with the result
         liveMatchService.createSession(match);

--- a/src/main/java/com/lollito/fm/service/SimulationMatchService.java
+++ b/src/main/java/com/lollito/fm/service/SimulationMatchService.java
@@ -61,6 +61,10 @@ public class SimulationMatchService {
 	}
 
 	public MatchResult simulate(Match match, String forcedResult, boolean updateRanking) {
+		return simulate(match, forcedResult, updateRanking, true);
+	}
+
+	public MatchResult simulate(Match match, String forcedResult, boolean updateRanking, boolean saveMatch) {
 		Integer stadiumCapacity = stadiumService.getCapacity(match.getHome().getStadium());
 		match.setSpectators(RandomUtils.randomValue(stadiumCapacity/3, stadiumCapacity));
 		
@@ -88,7 +92,9 @@ public class SimulationMatchService {
 		// Update player history stats
 		match.getPlayerStats().forEach(stats -> playerHistoryService.updateMatchStatistics(stats.getPlayer(), stats));
 
-		matchRepository.save(match);
+		if (saveMatch) {
+			matchRepository.save(match);
+		}
 
 		if (updateRanking) {
 			rankingService.update(match);

--- a/src/test/java/com/lollito/fm/service/MatchProcessorTest.java
+++ b/src/test/java/com/lollito/fm/service/MatchProcessorTest.java
@@ -84,7 +84,7 @@ class MatchProcessorTest {
         matchProcessor.processMatch(100L);
 
         // Verify simulation call
-        verify(simulationMatchService).simulate(eq(match), any(), eq(false));
+        verify(simulationMatchService).simulate(eq(match), any(), eq(false), eq(false));
 
         // Verify notifications sent to users via user-specific destination
         verify(messagingTemplate).convertAndSendToUser(


### PR DESCRIPTION
💡 **What:** Refactored `SimulationMatchService.simulate` to accept a `saveMatch` flag. Updated `MatchProcessor` to call `simulate` with `saveMatch=false`.
🎯 **Why:** `MatchProcessor` was saving the match redundantly: first inside `simulate` (as COMPLETED), then again in `processMatch` (as IN_PROGRESS). This caused unnecessary DB I/O and transiently incorrect match status.
📊 **Measured Improvement:** Verified correctness via `MatchProcessorTest`, `MatchProcessorReproductionTest` and `ServerServiceTest`. Removed one full entity save and associated event history inserts/deletes per match start.

---
*PR created automatically by Jules for task [2808476512968580268](https://jules.google.com/task/2808476512968580268) started by @lollito*