### PR TITLE
Secure AdminController with input validation

### DIFF
--- a/src/main/java/com/lollito/fm/controller/rest/AdminController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/AdminController.java
@@ -10,6 +10,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
 
+import jakarta.validation.Valid;
+
 import com.lollito.fm.model.*;
 import com.lollito.fm.model.dto.*;
 import com.lollito.fm.service.AdminService;
@@ -46,7 +48,7 @@ public class AdminController {
     }
 
     @PostMapping("/clubs")
-    public ResponseEntity<ClubDTO> createClub(@RequestBody CreateClubRequest request,
+    public ResponseEntity<ClubDTO> createClub(@Valid @RequestBody CreateClubRequest request,
                                             Authentication authentication) {
         User adminUser = getAdminUser(authentication);
         Club club = adminService.createClub(request, adminUser);
@@ -55,7 +57,7 @@ public class AdminController {
 
     @PutMapping("/clubs/{clubId}")
     public ResponseEntity<ClubDTO> updateClub(@PathVariable Long clubId,
-                                            @RequestBody UpdateClubRequest request,
+                                            @Valid @RequestBody UpdateClubRequest request,
                                             Authentication authentication) {
         User adminUser = getAdminUser(authentication);
         Club club = adminService.updateClub(clubId, request, adminUser);

--- a/src/main/java/com/lollito/fm/model/dto/CreateClubRequest.java
+++ b/src/main/java/com/lollito/fm/model/dto/CreateClubRequest.java
@@ -1,17 +1,36 @@
 package com.lollito.fm.model.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
 
 @Data
 public class CreateClubRequest {
+    @NotBlank(message = "Name is required")
     private String name;
+
     private String shortName;
+
+    @NotNull(message = "Founded year is required")
+    @Min(value = 1850, message = "Founded year must be after 1850")
     private Integer foundedYear;
+
+    @NotBlank(message = "City is required")
     private String city;
+
     private Long countryId;
+
+    @NotNull(message = "League ID is required")
     private Long leagueId;
+
+    @Min(value = 0, message = "Initial budget must be positive")
     private Integer initialBudget;
+
     private Boolean generateInitialSquad;
     private String squadQuality;
+
+    @Valid
     private CreateStadiumRequest stadiumRequest;
 }

--- a/src/main/java/com/lollito/fm/model/dto/CreateStadiumRequest.java
+++ b/src/main/java/com/lollito/fm/model/dto/CreateStadiumRequest.java
@@ -1,11 +1,18 @@
 package com.lollito.fm.model.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.Min;
 
 @Data
 public class CreateStadiumRequest {
     private String name;
+
+    @Min(value = 0, message = "Capacity must be positive")
     private Integer capacity;
+
+    @Min(value = 0, message = "Pitch quality must be positive")
     private Integer pitchQuality;
+
+    @Min(value = 0, message = "Facilities quality must be positive")
     private Integer facilitiesQuality;
 }

--- a/src/main/java/com/lollito/fm/model/dto/UpdateClubRequest.java
+++ b/src/main/java/com/lollito/fm/model/dto/UpdateClubRequest.java
@@ -1,13 +1,24 @@
 package com.lollito.fm.model.dto;
+
 import lombok.Data;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
+
 @Data
 public class UpdateClubRequest {
     private String name;
     private String shortName;
+
+    @Min(value = 1850, message = "Founded year must be after 1850")
     private Integer foundedYear;
+
     private String city;
     private Long countryId;
     private Long leagueId;
+
+    @Min(value = 0, message = "Initial budget must be positive")
     private Integer initialBudget;
+
+    @Valid
     private CreateStadiumRequest stadiumRequest;
 }

--- a/src/test/java/com/lollito/fm/controller/rest/AdminControllerValidationTest.java
+++ b/src/test/java/com/lollito/fm/controller/rest/AdminControllerValidationTest.java
@@ -1,0 +1,92 @@
+package com.lollito.fm.controller.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.mapper.ClubMapper;
+import com.lollito.fm.mapper.SystemConfigurationMapper;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.dto.ClubDTO;
+import com.lollito.fm.model.dto.CreateClubRequest;
+import com.lollito.fm.model.dto.UpdateClubRequest;
+import com.lollito.fm.service.AdminService;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AdminController.class)
+public class AdminControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AdminService adminService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ClubMapper clubMapper;
+
+    @MockBean
+    private SystemConfigurationMapper systemConfigurationMapper;
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void testCreateClubWithInvalidData() throws Exception {
+        CreateClubRequest request = new CreateClubRequest();
+        // Leaving fields null/empty to trigger validation (once added)
+        // e.g. name is null
+
+        when(userService.getUser("admin")).thenReturn(new User());
+        when(adminService.createClub(any(CreateClubRequest.class), any(User.class))).thenReturn(new Club());
+        when(clubMapper.toDto(any(Club.class))).thenReturn(new ClubDTO());
+
+        // Now expecting 400 Bad Request because validation is enabled.
+        mockMvc.perform(post("/api/admin/clubs")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+               .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void testUpdateClubWithInvalidData() throws Exception {
+        UpdateClubRequest request = new UpdateClubRequest();
+        request.setInitialBudget(-100); // Invalid
+
+        mockMvc.perform(put("/api/admin/clubs/1")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+               .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- Added `@Valid` annotation to `AdminController.createClub` and `updateClub` methods.
- Added validation annotations (`@NotBlank`, `@NotNull`, `@Min`) to `CreateClubRequest`, `UpdateClubRequest`, and `CreateStadiumRequest` DTOs.
- Ensured `CreateStadiumRequest.name` is optional to support partial updates in `UpdateClubRequest`.
- Added `AdminControllerValidationTest` to verify that invalid input returns `400 Bad Request`.

---
*PR created automatically by Jules for task [9502510911992843292](https://jules.google.com/task/9502510911992843292) started by @lollito*