### PR TITLE
⚡ Optimize ServerService N+1 player updates

### DIFF
--- a/src/main/java/com/lollito/fm/service/ServerService.java
+++ b/src/main/java/com/lollito/fm/service/ServerService.java
@@ -1,6 +1,7 @@
 package com.lollito.fm.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,13 +74,17 @@ public class ServerService {
 		ServerResponse serverResponse = new ServerResponse();
 		List<Match> matches = matchRepository.findByRoundSeasonAndDateBeforeAndFinish(league.getCurrentSeason(), LocalDateTime.now(), Boolean.FALSE);
 		if(matches.isEmpty()){
+			List<Player> allPlayers = new ArrayList<>();
 			for(Club club : league.getClubs()) {
 				for(Player player : club.getTeam().getPlayers()) {
 					double increment = -((10 * player.getStamina())/99) + (1000/99);
 					player.incrementCondition(increment);
+					allPlayers.add(player);
 				}
-				playerService.updateSkills(club.getTeam().getPlayers());
-				playerService.saveAll(club.getTeam().getPlayers());
+			}
+			if(!allPlayers.isEmpty()) {
+				playerService.updateSkills(allPlayers);
+				playerService.saveAll(allPlayers);
 			}
 		} else {
 			for (Match match : matches) {

--- a/src/test/java/com/lollito/fm/service/ServerServiceOptimizationTest.java
+++ b/src/test/java/com/lollito/fm/service/ServerServiceOptimizationTest.java
@@ -1,0 +1,82 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.mapper.MatchMapper;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.model.Team;
+import com.lollito.fm.repository.rest.MatchRepository;
+import com.lollito.fm.repository.rest.SeasonRepository;
+import com.lollito.fm.repository.rest.ServerRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ServerServiceOptimizationTest {
+
+    @InjectMocks
+    private ServerService serverService;
+
+    @Mock private MatchRepository matchRepository;
+    @Mock private PlayerService playerService;
+
+    // Mocks required for dependency injection but not used in this test path
+    @Mock private ServerRepository serverRepository;
+    @Mock private SeasonRepository seasonRepository;
+    @Mock private SeasonService seasonService;
+    @Mock private ClubService clubService;
+    @Mock private LeagueService leagueService;
+    @Mock private SimulationMatchService simulationMatchService;
+    @Mock private CountryService countryService;
+    @Mock private UserService userService;
+    @Mock private MatchMapper matchMapper;
+
+    @Test
+    public void testNextUpdatesPlayersInBatch() {
+        // Setup
+        League league = new League();
+        Season season = new Season();
+        league.setCurrentSeason(season);
+
+        List<Club> clubs = new ArrayList<>();
+        int clubCount = 5;
+        for (int i = 0; i < clubCount; i++) {
+            Club club = new Club();
+            Team team = new Team();
+            List<Player> players = new ArrayList<>();
+            Player player = new Player();
+            player.setStamina(80.0);
+            players.add(player);
+            team.setPlayers(players);
+            club.setTeam(team);
+            clubs.add(club);
+        }
+        league.setClubs(clubs);
+
+        // Mock empty matches to trigger the update logic
+        when(matchRepository.findByRoundSeasonAndDateBeforeAndFinish(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // Execute
+        serverService.next(league);
+
+        // Verify
+        // In the optimized implementation, saveAll is called once for all players.
+        verify(playerService, times(1)).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
Optimized the `ServerService.next` method to eliminate an N+1 query issue. Previously, `playerService.updateSkills` and `playerService.saveAll` were called for every club in the league. This change collects all players into a single list and performs the operations in a single batch call. A regression test `ServerServiceOptimizationTest` was added to verify the behavior.

---
*PR created automatically by Jules for task [17128091966997785005](https://jules.google.com/task/17128091966997785005) started by @lollito*