### PR TITLE
🔒 Fix hardcoded API URL in fm-web

### DIFF
--- a/fm-web/src/services/api.js
+++ b/fm-web/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const API_BASE_URL = 'http://localhost:8080';
+export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 const API_URL = API_BASE_URL + '/api';
 
 const api = axios.create({


### PR DESCRIPTION
**What:**
Fixed a hardcoded API URL vulnerability in `fm-web/src/services/api.js`.

**Risk:**
Hardcoded URLs prevent the application from being deployed to different environments (e.g., staging, production) and may leak internal development details.

**Solution:**
Replaced the hardcoded string with `process.env.REACT_APP_API_URL || 'http://localhost:8080'`. Added a `.env` file for local development. Verified with existing tests.

---
*PR created automatically by Jules for task [18231351552782291171](https://jules.google.com/task/18231351552782291171) started by @lollito*