### PR TITLE
Add FreeClubNotFoundException to ClubService

### DIFF
--- a/src/main/java/com/lollito/fm/exception/FreeClubNotFoundException.java
+++ b/src/main/java/com/lollito/fm/exception/FreeClubNotFoundException.java
@@ -1,0 +1,18 @@
+package com.lollito.fm.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class FreeClubNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public FreeClubNotFoundException() {
+        super("free club not found");
+    }
+
+    public FreeClubNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/lollito/fm/service/ClubService.java
+++ b/src/main/java/com/lollito/fm/service/ClubService.java
@@ -19,6 +19,7 @@ import com.lollito.fm.model.League;
 import com.lollito.fm.model.Stadium;
 import com.lollito.fm.repository.rest.ClubRepository;
 import com.lollito.fm.utils.RandomUtils;
+import com.lollito.fm.exception.FreeClubNotFoundException;
 
 @Service
 public class ClubService {
@@ -55,17 +56,16 @@ public class ClubService {
 		return clubRepository.count();
 	}
 	
-	//TODO exception free club not found
 	public Club findTopByLeagueCountryAndUserIsNull(Country country) {
-		return clubRepository.findTopByLeagueCountryAndUserIsNull(country).orElseThrow(() -> new RuntimeException("free club not found"));
+		return clubRepository.findTopByLeagueCountryAndUserIsNull(country).orElseThrow(FreeClubNotFoundException::new);
 	}
 
 	public Club findTopByLeagueServerAndLeagueCountryAndUserIsNull(Server server, Country country) {
-		return clubRepository.findTopByLeagueServerAndLeagueCountryAndUserIsNull(server, country).orElseThrow(() -> new RuntimeException("free club not found"));
+		return clubRepository.findTopByLeagueServerAndLeagueCountryAndUserIsNull(server, country).orElseThrow(FreeClubNotFoundException::new);
 	}
 	
 	public Club findTopByLeagueCountry(Country country) {
-		return clubRepository.findTopByLeagueCountry(country).orElseThrow(() -> new RuntimeException("free club not found"));
+		return clubRepository.findTopByLeagueCountry(country).orElseThrow(FreeClubNotFoundException::new);
 	}
 
 	public Club save(Club club) {

--- a/src/test/java/com/lollito/fm/service/ClubServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ClubServiceTest.java
@@ -1,0 +1,63 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.exception.FreeClubNotFoundException;
+import com.lollito.fm.model.Country;
+import com.lollito.fm.model.Server;
+import com.lollito.fm.repository.rest.ClubRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceTest {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private TeamService teamService;
+
+    @Mock
+    private NameService nameService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private ClubService clubService;
+
+    @Test
+    void findTopByLeagueCountryAndUserIsNull_ShouldThrowException_WhenClubNotFound() {
+        Country country = new Country();
+        when(clubRepository.findTopByLeagueCountryAndUserIsNull(country)).thenReturn(Optional.empty());
+
+        assertThrows(FreeClubNotFoundException.class, () -> clubService.findTopByLeagueCountryAndUserIsNull(country));
+    }
+
+    @Test
+    void findTopByLeagueServerAndLeagueCountryAndUserIsNull_ShouldThrowException_WhenClubNotFound() {
+        Server server = new Server();
+        Country country = new Country();
+        when(clubRepository.findTopByLeagueServerAndLeagueCountryAndUserIsNull(server, country))
+                .thenReturn(Optional.empty());
+
+        assertThrows(FreeClubNotFoundException.class, () -> clubService.findTopByLeagueServerAndLeagueCountryAndUserIsNull(server, country));
+    }
+
+    @Test
+    void findTopByLeagueCountry_ShouldThrowException_WhenClubNotFound() {
+        Country country = new Country();
+        when(clubRepository.findTopByLeagueCountry(country)).thenReturn(Optional.empty());
+
+        assertThrows(FreeClubNotFoundException.class, () -> clubService.findTopByLeagueCountry(country));
+    }
+}


### PR DESCRIPTION
Replaced generic RuntimeException with custom FreeClubNotFoundException in ClubService when a free club is not found. Added ClubServiceTest to verify the exception is thrown.

---
*PR created automatically by Jules for task [1211904997303129960](https://jules.google.com/task/1211904997303129960) started by @lollito*