### PR TITLE
Test MatchService.loadNext Upcoming Matches

### DIFF
--- a/src/test/java/com/lollito/fm/service/MatchServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/MatchServiceTest.java
@@ -1,0 +1,106 @@
+package com.lollito.fm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.Round;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.rest.MatchRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MatchRepository matchRepository;
+
+    @InjectMocks
+    private MatchService matchService;
+
+    private User user;
+    private Club club;
+    private League league;
+    private Season season;
+    private Round round;
+    private List<Round> rounds;
+
+    @BeforeEach
+    void setUp() {
+        // Construct the object graph
+        round = new Round(1);
+        round.setId(100L);
+
+        rounds = new ArrayList<>();
+        rounds.add(round); // Index 0
+
+        season = new Season();
+        season.setRounds(rounds);
+        // default nextRoundNumber is 1, so loadNext -> loadByRoundNumber(0) -> accesses rounds.get(0)
+
+        league = new League();
+        league.setCurrentSeason(season);
+
+        club = new Club();
+        club.setLeague(league);
+
+        user = new User();
+        user.setClub(club);
+    }
+
+    @Test
+    void loadNext_ShouldReturnMatches_WhenRoundExists() {
+        // Arrange
+        season.setNextRoundNumber(1);
+
+        Match match1 = new Match();
+        match1.setId(1L);
+        List<Match> expectedMatches = Collections.singletonList(match1);
+
+        when(userService.getLoggedUser()).thenReturn(user);
+        when(matchRepository.findByRoundIdWithClubs(round.getId())).thenReturn(expectedMatches);
+
+        // Act
+        List<Match> actualMatches = matchService.loadNext();
+
+        // Assert
+        assertThat(actualMatches).isEqualTo(expectedMatches);
+        verify(matchRepository).findByRoundIdWithClubs(round.getId());
+    }
+
+    @Test
+    void loadNext_ShouldReturnEmptyList_WhenRoundIndexOutOfBounds() {
+        // Arrange
+        // If nextRoundNumber is 2, loadNext tries to access index 1 (2-1).
+        // rounds only has 1 element (index 0). So size (1) <= number (1) is true.
+        season.setNextRoundNumber(2);
+
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        // Act
+        List<Match> actualMatches = matchService.loadNext();
+
+        // Assert
+        assertThat(actualMatches).isEmpty();
+        verifyNoInteractions(matchRepository);
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for `MatchService.loadNext`. The method relies on implicit state via `UserService` to navigate the `User -> Club -> League -> Season` object graph. The tests mock this chain of dependencies to verify that `loadNext` correctly identifies the next round using `nextRoundNumber` and retrieves the corresponding matches. It also covers the edge case where the calculated round index is out of bounds.

---
*PR created automatically by Jules for task [7989302341673246823](https://jules.google.com/task/7989302341673246823) started by @lollito*