### PR TITLE
🔒 Fix weak hardcoded JWT secret in production configuration

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: production
       JAVA_OPTS: -Xmx4g -Xms2g -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200
+      FM_APP_JWT_SECRET: ${JWT_SECRET}
+      FM_APP_JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS:-86400000}
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       SPRING_JPA_HIBERNATE_DDL_AUTO: ${DDL_AUTO:-update}
       JAVA_OPTS: ${JAVA_OPTS:--Xmx1g -Xms512m}
       SERVER_PORT: 8080
+      FM_APP_JWT_SECRET: ${JWT_SECRET}
+      FM_APP_JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS:-86400000}
     ports:
       - "8080:8080"
     volumes:

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -38,7 +38,5 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 #spring.mail.host=localhost
 #spring.mail.port=3025
 
-security.jwt.header=5
-security.jwt.prefix=5
-security.jwt.expiration=5
-security.jwt.secret=5
+fm.app.jwtSecret=${FM_APP_JWT_SECRET}
+fm.app.jwtExpirationMs=${FM_APP_JWT_EXPIRATION_MS:86400000}


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `src/main/resources/application-prod.properties` where a weak, hardcoded JWT secret (`security.jwt.secret=5`) was present.

⚠️ **Risk:** Although the hardcoded secret was technically unused by the application logic (which uses `fm.app.jwtSecret`), its presence was a security risk and misleading. Furthermore, the actual secret used in production was not explicitly configured to use an environment variable, potentially falling back to the default hardcoded dev secret.

🛡️ **Solution:**
- Removed unused `security.jwt.*` properties from `application-prod.properties`.
- Configured `fm.app.jwtSecret` and `fm.app.jwtExpirationMs` in `application-prod.properties` to use environment variables (`FM_APP_JWT_SECRET`, `FM_APP_JWT_EXPIRATION_MS`).
- Updated `docker-compose.prod.yml` and `docker-compose.yml` to inject these environment variables into the backend container.

---
*PR created automatically by Jules for task [12206411773525591930](https://jules.google.com/task/12206411773525591930) started by @lollito*