### PR TITLE
Implement generic stat modifications in DebugToolsService

### DIFF
--- a/src/main/java/com/lollito/fm/service/DebugToolsService.java
+++ b/src/main/java/com/lollito/fm/service/DebugToolsService.java
@@ -200,7 +200,14 @@ public class DebugToolsService {
                     player.setBirth(LocalDate.now().minusYears(Math.max(16, Math.min(45, player.getAge() + request.getAgeAdjustment()))));
                 }
 
-                // TODO: Implement stat modifications map if needed (requires mapping stat names to fields)
+                if (request.getOverallAdjustment() != null) {
+                    player.updateSkills(request.getOverallAdjustment().doubleValue());
+                    clampPlayerStats(player);
+                }
+
+                if (request.getStatModifications() != null) {
+                    request.getStatModifications().forEach((stat, value) -> applyStatModification(player, stat, value));
+                }
 
                 modifiedPlayers.add(playerRepository.save(player));
             }
@@ -522,5 +529,61 @@ public class DebugToolsService {
             .databaseConnectionsActive(0) // Mock
             .systemUptime(0.0) // Mock
             .build();
+    }
+
+    private void applyStatModification(Player player, String statName, Integer value) {
+        if (value == null) return;
+
+        switch (statName.toLowerCase()) {
+            case "stamina":
+                player.setStamina(clamp(player.getStamina(), value));
+                break;
+            case "playmaking":
+                player.setPlaymaking(clamp(player.getPlaymaking(), value));
+                break;
+            case "scoring":
+                player.setScoring(clamp(player.getScoring(), value));
+                break;
+            case "winger":
+                player.setWinger(clamp(player.getWinger(), value));
+                break;
+            case "goalkeeping":
+                player.setGoalkeeping(clamp(player.getGoalkeeping(), value));
+                break;
+            case "passing":
+                player.setPassing(clamp(player.getPassing(), value));
+                break;
+            case "defending":
+                player.setDefending(clamp(player.getDefending(), value));
+                break;
+            case "setpieces":
+            case "set_pieces":
+                player.setSetPieces(clamp(player.getSetPieces(), value));
+                break;
+            case "condition":
+                player.setCondition(clamp(player.getCondition(), value));
+                break;
+            case "moral":
+                player.setMoral(clamp(player.getMoral(), value));
+                break;
+            default:
+                log.warn("Unknown stat modification requested: {}", statName);
+        }
+    }
+
+    private Double clamp(Double currentValue, Integer modification) {
+        double val = (currentValue == null ? 0.0 : currentValue) + modification;
+        return Math.max(0.0, Math.min(100.0, val));
+    }
+
+    private void clampPlayerStats(Player player) {
+        player.setStamina(Math.max(0.0, Math.min(100.0, player.getStamina() != null ? player.getStamina() : 0.0)));
+        player.setPlaymaking(Math.max(0.0, Math.min(100.0, player.getPlaymaking() != null ? player.getPlaymaking() : 0.0)));
+        player.setScoring(Math.max(0.0, Math.min(100.0, player.getScoring() != null ? player.getScoring() : 0.0)));
+        player.setWinger(Math.max(0.0, Math.min(100.0, player.getWinger() != null ? player.getWinger() : 0.0)));
+        player.setGoalkeeping(Math.max(0.0, Math.min(100.0, player.getGoalkeeping() != null ? player.getGoalkeeping() : 0.0)));
+        player.setPassing(Math.max(0.0, Math.min(100.0, player.getPassing() != null ? player.getPassing() : 0.0)));
+        player.setDefending(Math.max(0.0, Math.min(100.0, player.getDefending() != null ? player.getDefending() : 0.0)));
+        player.setSetPieces(Math.max(0.0, Math.min(100.0, player.getSetPieces() != null ? player.getSetPieces() : 0.0)));
     }
 }

--- a/src/test/java/com/lollito/fm/service/DebugToolsServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/DebugToolsServiceTest.java
@@ -1,0 +1,108 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.model.DebugAction;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.dto.ModifyPlayerStatsRequest;
+import com.lollito.fm.repository.rest.DebugActionRepository;
+import com.lollito.fm.repository.rest.PlayerRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class DebugToolsServiceTest {
+
+    @Mock
+    private PlayerRepository playerRepository;
+
+    @Mock
+    private DebugActionRepository debugActionRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private DebugToolsService debugToolsService;
+
+    private User adminUser;
+    private Player player;
+
+    @BeforeEach
+    void setUp() {
+        adminUser = new User();
+        adminUser.setUsername("admin");
+
+        player = Player.builder()
+                .id(1L)
+                .name("John")
+                .surname("Doe")
+                .birth(LocalDate.of(2000, 1, 1))
+                .stamina(50.0)
+                .playmaking(50.0)
+                .scoring(50.0)
+                .winger(50.0)
+                .goalkeeping(50.0)
+                .passing(50.0)
+                .defending(50.0)
+                .setPieces(50.0)
+                .condition(100.0)
+                .moral(100.0)
+                .build();
+    }
+
+    @Test
+    void modifyPlayerStats_shouldUpdateStatsCorrectly() throws JsonProcessingException {
+        Map<String, Integer> statModifications = new HashMap<>();
+        statModifications.put("stamina", 10);
+        statModifications.put("passing", -5);
+        statModifications.put("condition", -10);
+
+        ModifyPlayerStatsRequest request = ModifyPlayerStatsRequest.builder()
+                .playerIds(Collections.singletonList(1L))
+                .statModifications(statModifications)
+                .overallAdjustment(2)
+                .build();
+
+        when(playerRepository.findAllById(any())).thenReturn(Collections.singletonList(player));
+        when(playerRepository.save(any(Player.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(debugActionRepository.save(any(DebugAction.class))).thenAnswer(invocation -> {
+            DebugAction action = invocation.getArgument(0);
+            if (action.getId() == null) {
+                action.setId(1L);
+            }
+            return action;
+        });
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        debugToolsService.modifyPlayerStats(request, adminUser);
+
+        // With overall first:
+        // stamina: 50 -> 52. Then +10 -> 62.
+        // passing: 50 -> 52. Then -5 -> 47.
+        // condition: 100 -> 100 (capped). Then -10 -> 90.
+        // scoring: 50 -> 52 (only overall)
+
+        assertEquals(62.0, player.getStamina(), 0.1, "Stamina check");
+        assertEquals(47.0, player.getPassing(), 0.1, "Passing check");
+        assertEquals(90.0, player.getCondition(), 0.1, "Condition check");
+        assertEquals(52.0, player.getScoring(), 0.1, "Scoring check");
+
+        verify(playerRepository, times(1)).save(player);
+    }
+}


### PR DESCRIPTION
Implemented modifyPlayerStats method in DebugToolsService to handle generic stat modifications via a map and overall adjustment. Added support for updating stats like stamina, playmaking, scoring, etc., ensuring values are clamped between 0.0 and 100.0. Added DebugToolsServiceTest to verify the implementation.

---
*PR created automatically by Jules for task [9011207425283874519](https://jules.google.com/task/9011207425283874519) started by @lollito*