### PR TITLE
🔒 Security Fix: Move JWT to HttpOnly Cookies

### DIFF
--- a/fm-web/src/components/Navbar.js
+++ b/fm-web/src/components/Navbar.js
@@ -48,7 +48,7 @@ const Navbar = ({ onToggleMenu }) => {
   useEffect(() => {
       if (!user) return;
 
-      const socket = new SockJS(API_BASE_URL + '/ws/live-match?token=' + user.accessToken);
+      const socket = new SockJS(API_BASE_URL + '/ws/live-match');
       stompClient.current = new Client({
           webSocketFactory: () => socket,
           onConnect: () => {

--- a/fm-web/src/context/AuthContext.js
+++ b/fm-web/src/context/AuthContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useEffect } from 'react';
+import api from '../services/api';
 
 export const AuthContext = createContext();
 
@@ -15,11 +16,17 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   const login = (userData) => {
-    localStorage.setItem('user', JSON.stringify(userData));
-    setUser(userData);
+    const { accessToken, ...userSafe } = userData;
+    localStorage.setItem('user', JSON.stringify(userSafe));
+    setUser(userSafe);
   };
 
-  const logout = () => {
+  const logout = async () => {
+    try {
+      await api.post('/user/logout');
+    } catch (error) {
+      console.error("Logout failed", error);
+    }
     localStorage.removeItem('user');
     setUser(null);
   };

--- a/fm-web/src/services/api.js
+++ b/fm-web/src/services/api.js
@@ -5,20 +5,8 @@ const API_URL = API_BASE_URL + '/api';
 
 const api = axios.create({
   baseURL: API_URL,
+  withCredentials: true,
 });
-
-api.interceptors.request.use(
-  (config) => {
-    const user = JSON.parse(localStorage.getItem('user'));
-    if (user && user.accessToken) {
-      config.headers['Authorization'] = 'Bearer ' + user.accessToken;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
 
 export const getPlayerHistory = (id) => api.get('/player-history/player/' + id);
 

--- a/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
@@ -81,8 +81,7 @@ public class WebSecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:3001"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-		configuration.setAllowedHeaders(Arrays.asList("authorization", "content-type", "x-auth-token"));
-		configuration.setExposedHeaders(Arrays.asList("x-auth-token"));
+		configuration.setAllowedHeaders(Arrays.asList("content-type"));
 		configuration.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/lollito/fm/config/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/com/lollito/fm/config/security/jwt/AuthTokenFilter.java
@@ -53,17 +53,7 @@ public class AuthTokenFilter extends OncePerRequestFilter {
   }
 
   private String parseJwt(HttpServletRequest request) {
-    String headerAuth = request.getHeader("Authorization");
-
-    if (StringUtils.hasText(headerAuth) && headerAuth.startsWith("Bearer ")) {
-      return headerAuth.substring(7);
-    }
-
-    String token = request.getParameter("token");
-    if (StringUtils.hasText(token)) {
-      return token;
-    }
-
-    return null;
+    String jwt = jwtUtils.getJwtFromCookies(request);
+    return jwt;
   }
 }

--- a/src/test/java/com/lollito/fm/controller/rest/UserControllerTest.java
+++ b/src/test/java/com/lollito/fm/controller/rest/UserControllerTest.java
@@ -1,0 +1,98 @@
+package com.lollito.fm.controller.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.rest.RegistrationRequest;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.service.UserService;
+import com.lollito.fm.mapper.UserMapper;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserMapper userMapper;
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    public void testLogin() throws Exception {
+        RegistrationRequest request = new RegistrationRequest();
+        request.setUsername("user");
+        request.setPassword("password");
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("user");
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            new org.springframework.security.core.userdetails.User("user", "password", java.util.Collections.emptyList()),
+            "password",
+            java.util.Collections.emptyList()
+        );
+
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+        when(userService.findByUsernameAndActive("user")).thenReturn(user);
+
+        ResponseCookie cookie = ResponseCookie.from("fm_jwt", "token").path("/").maxAge(100).httpOnly(true).build();
+        when(jwtUtils.generateJwtCookie(any(User.class))).thenReturn(cookie);
+
+        mockMvc.perform(post("/api/user/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("fm_jwt", "token"))
+                .andExpect(cookie().httpOnly("fm_jwt", true))
+                .andExpect(cookie().path("fm_jwt", "/"))
+                .andExpect(cookie().maxAge("fm_jwt", 100));
+    }
+
+    @Test
+    public void testLogout() throws Exception {
+        ResponseCookie cookie = ResponseCookie.from("fm_jwt", "").path("/").maxAge(0).build();
+        when(jwtUtils.getCleanJwtCookie()).thenReturn(cookie);
+
+        mockMvc.perform(post("/api/user/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("fm_jwt", ""))
+                .andExpect(cookie().maxAge("fm_jwt", 0));
+    }
+}


### PR DESCRIPTION
This PR addresses a security vulnerability where the JWT access token was stored in `localStorage` and sent via the `Authorization` header, exposing it to XSS attacks.

**Changes:**
- **Backend:**
    - Implemented `HttpOnly`, `SameSite=Strict` cookie generation for JWTs.
    - Modified `UserController` to set the cookie on successful login/registration.
    - Added a `logout` endpoint to clear the cookie.
    - Updated `AuthTokenFilter` to extract the token from the cookie.
    - Tightened CORS configuration in `WebSecurityConfig`.
- **Frontend (`fm-web`):**
    - Configured Axios to send credentials (cookies).
    - Removed logic that stored the token in `localStorage` and attached it to requests.
    - Updated WebSocket connection to rely on the cookie instead of a query parameter.

**Verification:**
- Added `UserControllerTest` verifying `Set-Cookie` headers on login and logout.
- Ran backend tests (`mvn test`) - All passed.
- Ran frontend tests (`npm test`) - All passed.

---
*PR created automatically by Jules for task [15336377543516220082](https://jules.google.com/task/15336377543516220082) started by @lollito*