### PR TITLE
⚡ Optimize MatchProcessor Event Persistence

### DIFF
--- a/src/main/java/com/lollito/fm/model/EventHistory.java
+++ b/src/main/java/com/lollito/fm/model/EventHistory.java
@@ -3,12 +3,16 @@ package com.lollito.fm.model;
 import java.io.Serializable;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -39,6 +43,12 @@ public class EventHistory implements Serializable{
 	@EqualsAndHashCode.Include
 	private Long id;
 	
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id")
+    @JsonIgnore
+    @ToString.Exclude
+    private Match match;
+
 	private String event;
 	
 	private Integer minute;

--- a/src/main/java/com/lollito/fm/model/Match.java
+++ b/src/main/java/com/lollito/fm/model/Match.java
@@ -92,8 +92,7 @@ public class Match implements Serializable{
 	
 	public Integer spectators;
 	
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
-    @JoinColumn( name = "match_id" )
+	@OneToMany(mappedBy = "match", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	@OrderBy("minute")
 	@Builder.Default
 	@ToString.Exclude

--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -96,8 +96,12 @@ public class MatchProcessor {
             // Restore Events
             List<EventHistoryDTO> eventDTOs = objectMapper.readValue(session.getEvents(), new TypeReference<List<EventHistoryDTO>>(){});
             List<EventHistory> events = eventDTOs.stream().map(matchMapper::toEntity).collect(Collectors.toList());
-            events.forEach(e -> e.setId(null));
+
             match.getEvents().clear();
+            events.forEach(e -> {
+                e.setId(null);
+                e.setMatch(match);
+            });
             match.getEvents().addAll(events);
 
             // Restore Stats


### PR DESCRIPTION
Optimized `MatchProcessor.finalizeMatch` by refactoring the `Match`-`EventHistory` relationship from Unidirectional to Bidirectional. This architectural change allows for more efficient database operations (avoiding separate UPDATE statements for FKs) and ensures better scalability. The `finalizeMatch` method was updated to properly maintain the bidirectional relationship in memory, ensuring safety and consistency. Verified with reproduction tests and existing test suite.

---
*PR created automatically by Jules for task [8145818872440011431](https://jules.google.com/task/8145818872440011431) started by @lollito*