### PR TITLE
⚡ Optimize LoanService N+1 Query Issue

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/LoanAgreementRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/LoanAgreementRepository.java
@@ -1,14 +1,21 @@
 package com.lollito.fm.repository.rest;
 
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import com.lollito.fm.model.Club;
 import com.lollito.fm.model.LoanAgreement;
 import com.lollito.fm.model.LoanStatus;
-import com.lollito.fm.model.Club;
 
 @Repository
 public interface LoanAgreementRepository extends JpaRepository<LoanAgreement, Long> {
+    @Query("SELECT l FROM LoanAgreement l JOIN FETCH l.player WHERE l.status = :status")
+    List<LoanAgreement> findWithPlayerByStatus(@Param("status") LoanStatus status);
+
     List<LoanAgreement> findByStatus(LoanStatus status);
     List<LoanAgreement> findByParentClub(Club club);
     List<LoanAgreement> findByLoanClub(Club club);

--- a/src/main/java/com/lollito/fm/repository/rest/PlayerSeasonStatsRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/PlayerSeasonStatsRepository.java
@@ -18,6 +18,8 @@ public interface PlayerSeasonStatsRepository extends JpaRepository<PlayerSeasonS
 
     Optional<PlayerSeasonStats> findByPlayerAndSeason(Player player, Season season);
 
+    List<PlayerSeasonStats> findBySeasonAndPlayerIn(Season season, List<Player> players);
+
     List<PlayerSeasonStats> findByPlayer(Player player);
 
     List<PlayerSeasonStats> findByPlayerOrderBySeasonDesc(Player player);

--- a/src/main/java/com/lollito/fm/service/PlayerHistoryService.java
+++ b/src/main/java/com/lollito/fm/service/PlayerHistoryService.java
@@ -2,7 +2,9 @@ package com.lollito.fm.service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -330,6 +332,15 @@ public class PlayerHistoryService {
 
         return playerSeasonStatsRepository.findByPlayerAndSeason(player, season)
                 .orElseThrow(() -> new EntityNotFoundException("Stats not found"));
+    }
+
+    public Map<Long, PlayerSeasonStats> getSeasonStatsForPlayers(List<Player> players, Season season) {
+        if (players == null || players.isEmpty()) {
+            return new HashMap<>();
+        }
+        List<PlayerSeasonStats> statsList = playerSeasonStatsRepository.findBySeasonAndPlayerIn(season, players);
+        return statsList.stream()
+                .collect(Collectors.toMap(stats -> stats.getPlayer().getId(), stats -> stats));
     }
 
     public List<PlayerAchievement> getPlayerAchievements(Long playerId) {

--- a/src/test/java/com/lollito/fm/service/LoanServicePerformanceTest.java
+++ b/src/test/java/com/lollito/fm/service/LoanServicePerformanceTest.java
@@ -1,0 +1,96 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.LoanAgreement;
+import com.lollito.fm.model.LoanStatus;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.PlayerSeasonStats;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.repository.rest.ClubRepository;
+import com.lollito.fm.repository.rest.LoanAgreementRepository;
+import com.lollito.fm.repository.rest.LoanPerformanceReviewRepository;
+import com.lollito.fm.repository.rest.LoanProposalRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class LoanServicePerformanceTest {
+
+    @Mock private LoanAgreementRepository loanAgreementRepository;
+    @Mock private LoanProposalRepository loanProposalRepository;
+    @Mock private LoanPerformanceReviewRepository performanceReviewRepository;
+    @Mock private PlayerService playerService;
+    @Mock private ClubService clubService;
+    @Mock private ClubRepository clubRepository;
+    @Mock private FinancialService financialService;
+    @Mock private PlayerHistoryService playerHistoryService;
+    @Mock private SeasonService seasonService;
+    @Mock private NewsService newsService;
+
+    @InjectMocks
+    private LoanService loanService;
+
+    @Test
+    public void testProcessMonthlyLoanReviews_PerformanceOptimized() {
+        // Setup
+        int loanCount = 100;
+        List<LoanAgreement> loans = new ArrayList<>();
+        Season season = new Season();
+        season.setId(1L);
+
+        when(seasonService.getCurrentSeason()).thenReturn(season);
+
+        Map<Long, PlayerSeasonStats> statsMap = new HashMap<>();
+
+        for (int i = 0; i < loanCount; i++) {
+            Player player = new Player();
+            player.setId((long) i);
+
+            LoanAgreement loan = LoanAgreement.builder()
+                    .id((long) i)
+                    .player(player)
+                    .status(LoanStatus.ACTIVE)
+                    .build();
+            loans.add(loan);
+
+            statsMap.put(player.getId(), new PlayerSeasonStats());
+        }
+
+        when(loanAgreementRepository.findWithPlayerByStatus(LoanStatus.ACTIVE)).thenReturn(loans);
+        when(playerHistoryService.getSeasonStatsForPlayers(any(), eq(season))).thenReturn(statsMap);
+
+        // Execute
+        loanService.processMonthlyLoanReviews();
+
+        // Verify Optimized Behavior
+
+        // 1. Verify findWithPlayerByStatus is called instead of findByStatus
+        verify(loanAgreementRepository, times(1)).findWithPlayerByStatus(LoanStatus.ACTIVE);
+        verify(loanAgreementRepository, never()).findByStatus(LoanStatus.ACTIVE);
+
+        // 2. Verify bulk fetch for stats is called once
+        verify(playerHistoryService, times(1)).getSeasonStatsForPlayers(any(), eq(season));
+
+        // 3. Verify N+1 is gone: getPlayerSeasonStats should NOT be called
+        verify(playerHistoryService, never()).getPlayerSeasonStats(any(Long.class), any(Long.class));
+
+        // 4. Verify loop execution: save is still called N times for reviews and loan updates
+        verify(performanceReviewRepository, times(loanCount)).save(any());
+        verify(loanAgreementRepository, times(loanCount)).save(any(LoanAgreement.class));
+    }
+}


### PR DESCRIPTION
This PR addresses the N+1 query performance issue in `LoanService.processMonthlyLoanReviews`.
Previously, the method fetched active loans and then iteratively fetched player season stats for each loan, resulting in N+1 queries.

Changes:
- Added `findWithPlayerByStatus` to `LoanAgreementRepository` to eagerly fetch `Player` with `LoanAgreement`.
- Added `findBySeasonAndPlayerIn` to `PlayerSeasonStatsRepository` to support bulk retrieval of stats.
- Added `getSeasonStatsForPlayers` to `PlayerHistoryService` to orchestrate the bulk fetch.
- Refactored `LoanService.processMonthlyLoanReviews` to:
    - Fetch loans with players in one query.
    - Extract players and fetch their season stats in one query.
    - Iterate and create reviews using the pre-fetched stats.
- Added `LoanServicePerformanceTest` to verify that `getPlayerSeasonStats` (single fetch) is no longer called during the process.

This optimization significantly reduces the number of database round-trips for the monthly loan review process.

---
*PR created automatically by Jules for task [14486510346750446959](https://jules.google.com/task/14486510346750446959) started by @lollito*