### PR TITLE
Fix Training Plan save failure on Rest Day selection

### DIFF
--- a/fm-web/src/components/TrainingPlan.js
+++ b/fm-web/src/components/TrainingPlan.js
@@ -45,7 +45,19 @@ const TrainingPlan = ({ teamId }) => {
     const handleSave = async () => {
         setSaving(true);
         try {
-            const response = await updateTrainingPlan(teamId, plan);
+            const payload = {
+                mondayFocus: plan.mondayFocus || null,
+                tuesdayFocus: plan.tuesdayFocus || null,
+                wednesdayFocus: plan.wednesdayFocus || null,
+                thursdayFocus: plan.thursdayFocus || null,
+                fridayFocus: plan.fridayFocus || null,
+                saturdayFocus: plan.saturdayFocus || null,
+                sundayFocus: plan.sundayFocus || null,
+                intensity: plan.intensity,
+                restOnWeekends: plan.restOnWeekends || false
+            };
+
+            const response = await updateTrainingPlan(teamId, payload);
             setPlan(response.data);
             showToast('Training plan saved successfully!', 'success');
         } catch (error) {

--- a/fm-web/src/components/TrainingPlan.test.js
+++ b/fm-web/src/components/TrainingPlan.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import TrainingPlan from './TrainingPlan';
+import { getTrainingPlan, updateTrainingPlan } from '../services/api';
+import { useToast } from '../context/ToastContext';
+
+// Mock dependencies
+jest.mock('../services/api');
+jest.mock('../context/ToastContext');
+
+describe('TrainingPlan Component', () => {
+    const mockShowToast = jest.fn();
+    const mockUpdateTrainingPlan = jest.fn();
+    const mockGetTrainingPlan = jest.fn();
+
+    beforeEach(() => {
+        useToast.mockReturnValue({ showToast: mockShowToast });
+        updateTrainingPlan.mockImplementation(mockUpdateTrainingPlan);
+        getTrainingPlan.mockImplementation(mockGetTrainingPlan);
+        jest.clearAllMocks();
+    });
+
+    test('sanitizes payload on save by converting empty strings to null', async () => {
+        const initialPlan = {
+            id: 1,
+            mondayFocus: 'ATTACKING',
+            tuesdayFocus: 'DEFENDING',
+            wednesdayFocus: 'PHYSICAL',
+            thursdayFocus: 'TECHNICAL',
+            fridayFocus: 'GOALKEEPING',
+            saturdayFocus: 'BALANCED',
+            sundayFocus: 'ATTACKING', // Will change this to Rest Day
+            intensity: 'MODERATE',
+            restOnWeekends: false,
+            lastUpdated: '2023-01-01'
+        };
+
+        mockGetTrainingPlan.mockResolvedValue({ data: initialPlan });
+        // updateTrainingPlan should return the updated plan (or at least valid data)
+        mockUpdateTrainingPlan.mockResolvedValue({ data: { ...initialPlan, sundayFocus: null } });
+
+        await act(async () => {
+            render(<TrainingPlan teamId={1} />);
+        });
+
+        // Wait for loading to finish
+        expect(await screen.findByText('Training Plan')).toBeInTheDocument();
+
+        // Find the Sunday dropdown
+        // The label is "Sunday"
+        // The select is next to it.
+        // We can find by combobox role? Or by label text if associated.
+        // The current implementation:
+        // <label ...>Sunday</label> <select ...>
+        // They are siblings, not nested. So getByLabelText won't work automatically unless 'for' attribute is used.
+        // I'll use getAllByRole('combobox')[6] (Sunday is last).
+
+        const selects = screen.getAllByRole('combobox');
+        const sundaySelect = selects[6]; // Sunday is the 7th day
+
+        // Verify initial value
+        expect(sundaySelect.value).toBe('ATTACKING');
+
+        // Change to Rest Day (value "")
+        fireEvent.change(sundaySelect, { target: { value: '' } });
+
+        // Click Save
+        const saveButton = screen.getByText('Save Training Plan');
+        fireEvent.click(saveButton);
+
+        // Verify updateTrainingPlan call
+        await waitFor(() => {
+            expect(mockUpdateTrainingPlan).toHaveBeenCalledTimes(1);
+        });
+
+        const expectedPayload = {
+            mondayFocus: 'ATTACKING',
+            tuesdayFocus: 'DEFENDING',
+            wednesdayFocus: 'PHYSICAL',
+            thursdayFocus: 'TECHNICAL',
+            fridayFocus: 'GOALKEEPING',
+            saturdayFocus: 'BALANCED',
+            sundayFocus: null, // This is the crucial check!
+            intensity: 'MODERATE',
+            restOnWeekends: false
+        };
+
+        expect(mockUpdateTrainingPlan).toHaveBeenCalledWith(1, expectedPayload);
+    });
+});


### PR DESCRIPTION
The "Training" tab in the Team page had an issue where selecting "Rest Day" (which sets the focus to an empty string `""`) would cause the save operation to fail, likely due to backend Enum deserialization issues.

This change sanitizes the payload in `handleSave` to convert any empty string values for training focus to `null`, which is the expected value for "Rest Day" (no training). It also ensures only the relevant fields are sent to the backend.

A unit test was added to verify this behavior.

---
*PR created automatically by Jules for task [18423257201126602516](https://jules.google.com/task/18423257201126602516) started by @lollito*