### PR TITLE
Fix Training History tab display and performance

### DIFF
--- a/fm-web/src/components/TrainingHistory.js
+++ b/fm-web/src/components/TrainingHistory.js
@@ -79,7 +79,7 @@ const TrainingHistory = ({ teamId }) => {
                             <span className="session-intensity">{session.intensity}</span>
                         </div>
                         <div className="session-stats" style={{ fontSize: '0.9em', color: '#666', marginTop: '5px' }}>
-                            <span style={{ marginRight: '15px' }}>Players trained: {session.playerResults ? session.playerResults.length : 'N/A'}</span>
+                            <span style={{ marginRight: '15px' }}>Players trained: {session.playerCount !== undefined ? session.playerCount : 'N/A'}</span>
                             <span>Effectiveness: {session.effectivenessMultiplier ? Math.round(session.effectivenessMultiplier * 100) : 0}%</span>
                         </div>
                     </div>

--- a/src/main/java/com/lollito/fm/mapper/TrainingMapper.java
+++ b/src/main/java/com/lollito/fm/mapper/TrainingMapper.java
@@ -17,6 +17,8 @@ public interface TrainingMapper {
     TrainingPlanDTO toDto(TrainingPlan plan);
 
     @Mapping(source = "team.id", target = "teamId")
+    @Mapping(target = "playerCount", expression = "java(session.getPlayerResults() != null ? session.getPlayerResults().size() : 0)")
+    @Mapping(target = "playerResults", ignore = true)
     TrainingSessionDTO toDto(TrainingSession session);
 
     @Mapping(source = "trainingSession.id", target = "trainingSessionId")

--- a/src/main/java/com/lollito/fm/model/dto/TrainingSessionDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/TrainingSessionDTO.java
@@ -19,5 +19,6 @@ public class TrainingSessionDTO {
     private LocalDate endDate;
     private TrainingStatus status;
     private Double effectivenessMultiplier;
+    private Integer playerCount;
     private List<PlayerTrainingResultDTO> playerResults;
 }

--- a/src/main/java/com/lollito/fm/service/TrainingService.java
+++ b/src/main/java/com/lollito/fm/service/TrainingService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Player;
@@ -302,11 +303,13 @@ public class TrainingService {
          return team.getCurrentTrainingPlan();
     }
 
+    @Transactional(readOnly = true)
     public Page<TrainingSession> getTrainingHistory(Long teamId, Pageable pageable) {
         Team team = teamService.findById(teamId);
         return trainingSessionRepository.findByTeam(team, pageable);
     }
 
+    @Transactional(readOnly = true)
     public List<PlayerTrainingResult> getSessionResults(Long sessionId) {
         return trainingSessionRepository.findById(sessionId)
             .map(TrainingSession::getPlayerResults)


### PR DESCRIPTION
This PR addresses an issue where the Training History tab would display "N/A" for the number of players trained or potentially fail to load due to performance issues or lazy initialization exceptions.

Changes:
1.  **Backend:**
    *   Updated `TrainingSessionDTO` to carry a `playerCount` integer instead of the full list of `playerResults`.
    *   Updated `TrainingMapper` to calculate `playerCount` from the lazy-loaded collection (triggering the count) and explicitly ignore `playerResults` during serialization. This reduces the JSON payload size significantly for the history list.
    *   Added `@Transactional(readOnly = true)` to `TrainingService` methods `getTrainingHistory` and `getSessionResults` to ensure that lazy loading of `playerResults` (for the count) occurs within a transaction boundary, preventing `LazyInitializationException`.

2.  **Frontend:**
    *   Updated `fm-web/src/components/TrainingHistory.js` to render `session.playerCount` instead of `session.playerResults.length`.

These changes ensure the Training History tab loads correctly and more efficiently.

---
*PR created automatically by Jules for task [15103672936359796673](https://jules.google.com/task/15103672936359796673) started by @lollito*