### PR TITLE
Implement force finish and reset for live matches

### DIFF
--- a/src/main/java/com/lollito/fm/controller/LiveMatchController.java
+++ b/src/main/java/com/lollito/fm/controller/LiveMatchController.java
@@ -46,4 +46,16 @@ public class LiveMatchController {
         // Logic for tracking spectators could go here
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/{id}/finish")
+    public ResponseEntity<Void> finishLiveMatch(@PathVariable Long id) {
+        liveMatchService.forceFinish(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/reset")
+    public ResponseEntity<Void> resetLiveMatch(@PathVariable Long id) {
+        liveMatchService.reset(id);
+        return ResponseEntity.ok().build();
+    }
 }


### PR DESCRIPTION
Implemented `forceFinish` and `reset` methods in `LiveMatchService`.
`forceFinish` allows an admin or system to manually complete a live match, triggering the finalization process.
`reset` allows resetting a match to its initial state (SCHEDULED, no score, no events), enabling it to be re-simulated. Note that side effects on players (condition, injuries) from the initial simulation are not reverted.
Exposed these capabilities via new REST endpoints in `LiveMatchController`.
Verified with unit tests covering both scenarios.

---
*PR created automatically by Jules for task [2911067705620130118](https://jules.google.com/task/2911067705620130118) started by @lollito*