### PR TITLE
Add Force Next Day and Delete Server buttons to ServerManagement

### DIFF
--- a/fm-admin/src/pages/ServerManagement.js
+++ b/fm-admin/src/pages/ServerManagement.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getServers, createServer } from '../services/api';
+import { getServers, createServer, forceNextDay, deleteServer } from '../services/api';
 import { useToast } from '../context/ToastContext';
 import Layout from '../components/Layout';
 
@@ -34,9 +34,33 @@ const ServerManagement = () => {
     }
   }
 
+  const handleNextDay = async () => {
+    try {
+        await forceNextDay();
+        showToast('Forced next day successfully', 'success');
+        fetchServers();
+    } catch(e) {
+        showToast('Error forcing next day', 'error');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if(!window.confirm('Are you sure you want to delete this server?')) return;
+    try {
+        await deleteServer(id);
+        showToast('Server deleted successfully', 'success');
+        fetchServers();
+    } catch(e) {
+        showToast('Error deleting server', 'error');
+    }
+  };
+
   return (
     <Layout>
-      <h1 style={{ color: 'var(--text)', marginBottom: '32px' }}>Server Management</h1>
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h1 style={{ color: 'var(--text)', marginBottom: 0 }}>Server Management</h1>
+        <button className="btn btn-warning" onClick={handleNextDay}>Force Next Day</button>
+      </div>
 
       <div className="card mb-4">
         <div className="card-header">Create Server</div>
@@ -65,6 +89,7 @@ const ServerManagement = () => {
                         <th>ID</th>
                         <th>Name</th>
                         <th>Current Date</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -73,6 +98,9 @@ const ServerManagement = () => {
                             <td>{s.id}</td>
                             <td>{s.name}</td>
                             <td>{s.currentDate}</td>
+                            <td>
+                                <button className="btn btn-danger btn-sm" onClick={() => handleDelete(s.id)}>Delete</button>
+                            </td>
                         </tr>
                     ))}
                 </tbody>

--- a/fm-admin/src/services/api.js
+++ b/fm-admin/src/services/api.js
@@ -34,6 +34,8 @@ export const updateSystemConfiguration = (id, newValue) => api.put(`/admin/confi
 
 export const getServers = () => api.get('/server/findAll');
 export const createServer = (serverName) => api.post('/server/?serverName=' + serverName);
+export const forceNextDay = () => api.post('/server/next');
+export const deleteServer = (serverId) => api.delete('/server/?serverId=' + serverId);
 
 export const getAllLiveMatches = () => api.get('/live-match/all');
 


### PR DESCRIPTION
This PR updates the `fm-admin` Server Management page to include administrative actions for forcing the next simulation day and deleting servers.

Changes:
-   `fm-admin/src/services/api.js`: Added `forceNextDay` (`POST /server/next`) and `deleteServer` (`DELETE /server/?serverId={id}`) API wrappers.
-   `fm-admin/src/pages/ServerManagement.js`:
    -   Added "Force Next Day" button to the page header.
    -   Added "Actions" column to the server table with a "Delete" button for each server.
    -   Added confirmation dialog for server deletion.
    -   Added toast notifications for success/error feedback.

Verified via Playwright script mocking the API and checking UI element visibility and interactions.

---
*PR created automatically by Jules for task [4958118624246249986](https://jules.google.com/task/4958118624246249986) started by @lollito*