### PR TITLE
Implement Player Tools in Debug Tools

### DIFF
--- a/fm-admin/src/services/api.js
+++ b/fm-admin/src/services/api.js
@@ -18,6 +18,7 @@ export const getTestScenarios = () => api.get('/admin/debug/test-scenarios');
 export const executeTestScenario = (id) => api.post('/admin/debug/test-scenarios/' + id + '/execute');
 export const getPerformanceMetrics = (params) => api.get('/admin/debug/metrics', { params });
 export const getDebugActions = (params) => api.get('/admin/debug/actions', { params });
+export const getPlayer = (id) => api.get('/admin/debug/players/' + id);
 export const getAdminDashboard = () => api.get('/admin/dashboard');
 export const getClubs = () => api.get('/admin/clubs');
 export const createClub = (data) => api.post('/admin/clubs', data);

--- a/fm-admin/src/styles/DebugTools.css
+++ b/fm-admin/src/styles/DebugTools.css
@@ -270,3 +270,84 @@ button:disabled {
     font-size: 1.2rem;
     color: #6c757d;
 }
+
+/* Player Tools */
+.player-tools {
+    margin-top: 20px;
+}
+
+.search-box {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.search-box input {
+    padding: 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    flex: 1;
+    max-width: 300px;
+}
+
+.player-editor {
+    background: #f8f9fa;
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #dee2e6;
+}
+
+.player-info {
+    margin-bottom: 20px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.stat-input {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-input label {
+    font-size: 0.85rem;
+    color: #495057;
+    margin-bottom: 5px;
+    font-weight: 600;
+}
+
+.stat-input input {
+    padding: 8px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.btn-success {
+    background-color: #28a745;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.btn-success:hover {
+    background-color: #218838;
+}
+
+.btn-success:disabled {
+    background-color: #94d3a2;
+    cursor: not-allowed;
+}

--- a/src/main/java/com/lollito/fm/controller/DebugToolsController.java
+++ b/src/main/java/com/lollito/fm/controller/DebugToolsController.java
@@ -41,6 +41,7 @@ import com.lollito.fm.model.dto.SimulateMatchesRequest;
 import com.lollito.fm.model.dto.SystemSnapshotDTO;
 import com.lollito.fm.model.dto.TestExecutionDTO;
 import com.lollito.fm.model.dto.TestScenarioDTO;
+import com.lollito.fm.dto.PlayerDTO;
 import com.lollito.fm.service.DebugToolsService;
 import com.lollito.fm.service.UserService;
 
@@ -85,6 +86,11 @@ public class DebugToolsController {
         User adminUser = userService.getUser(authentication.getName());
         DebugActionResult result = debugToolsService.modifyPlayerStats(request, adminUser);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/players/{id}")
+    public ResponseEntity<PlayerDTO> getPlayer(@PathVariable Long id) {
+        return ResponseEntity.ok(debugToolsService.getPlayer(id));
     }
 
     @PostMapping("/finances/adjust")

--- a/src/main/java/com/lollito/fm/service/DebugToolsService.java
+++ b/src/main/java/com/lollito/fm/service/DebugToolsService.java
@@ -61,6 +61,8 @@ import com.lollito.fm.repository.rest.PlayerRepository;
 import com.lollito.fm.repository.rest.SystemSnapshotRepository;
 import com.lollito.fm.repository.rest.TestExecutionRepository;
 import com.lollito.fm.repository.rest.TestScenarioRepository;
+import com.lollito.fm.dto.PlayerDTO;
+import com.lollito.fm.mapper.PlayerMapper;
 
 import jakarta.persistence.EntityNotFoundException;
 
@@ -83,6 +85,7 @@ public class DebugToolsService {
     @Autowired private TestScenarioRepository testScenarioRepository;
     @Autowired private TestExecutionRepository testExecutionRepository;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private PlayerMapper playerMapper;
 
     public DebugDashboardDTO getDebugDashboard() {
         LocalDateTime now = LocalDateTime.now();
@@ -383,6 +386,12 @@ public class DebugToolsService {
 
     public List<SystemSnapshot> getSystemSnapshots() {
         return systemSnapshotRepository.findAll();
+    }
+
+    public PlayerDTO getPlayer(Long id) {
+        return playerRepository.findById(id)
+                .map(playerMapper::toDto)
+                .orElseThrow(() -> new EntityNotFoundException("Player not found with id: " + id));
     }
 
     public List<TestScenario> getTestScenarios() {

--- a/src/test/java/com/lollito/fm/controller/DebugToolsControllerTest.java
+++ b/src/test/java/com/lollito/fm/controller/DebugToolsControllerTest.java
@@ -1,0 +1,61 @@
+package com.lollito.fm.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.dto.PlayerDTO;
+import com.lollito.fm.service.DebugToolsService;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.service.UserService;
+
+@WebMvcTest(controllers = DebugToolsController.class)
+public class DebugToolsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DebugToolsService debugToolsService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void testGetPlayer() throws Exception {
+        PlayerDTO player = new PlayerDTO();
+        player.setId(1L);
+        player.setName("Test");
+        player.setSurname("Player");
+        player.setStamina(80.0);
+
+        when(debugToolsService.getPlayer(1L)).thenReturn(player);
+
+        mockMvc.perform(get("/api/admin/debug/players/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.id").value(1))
+               .andExpect(jsonPath("$.name").value("Test"))
+               .andExpect(jsonPath("$.surname").value("Player"))
+               .andExpect(jsonPath("$.stamina").value(80.0));
+    }
+}


### PR DESCRIPTION
Implemented the `PlayerTools` component in `fm-admin/src/pages/DebugTools.js` to allow admins to search for players by ID and modify their stats.
- Added `GET /api/admin/debug/players/{id}` endpoint in `DebugToolsController`.
- Implemented `getPlayer` in `DebugToolsService` returning `PlayerDTO`.
- Added `getPlayer` function in `fm-admin/src/services/api.js`.
- Implemented `PlayerTools` UI with search input, stats grid, and update button.
- Added unit test `DebugToolsControllerTest` covering the new endpoint.
- Verified frontend functionality using Playwright script.

---
*PR created automatically by Jules for task [15626545685431004045](https://jules.google.com/task/15626545685431004045) started by @lollito*