### PR TITLE
Fix NullPointerException in RankingService.load()

### DIFF
--- a/src/main/java/com/lollito/fm/service/RankingService.java
+++ b/src/main/java/com/lollito/fm/service/RankingService.java
@@ -15,7 +15,9 @@ import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Match;
 import com.lollito.fm.model.Ranking;
 import com.lollito.fm.model.Season;
+import com.lollito.fm.model.User;
 import com.lollito.fm.repository.rest.RankingRepository;
+import java.util.Collections;
 
 @Service
 public class RankingService {
@@ -78,6 +80,10 @@ public class RankingService {
 	}
 
 	public List<Ranking> load(){
-		return userService.getLoggedUser().getClub().getLeague().getCurrentSeason().getRankingLines();
+		User user = userService.getLoggedUser();
+		if (user != null && user.getClub() != null) {
+			return user.getClub().getLeague().getCurrentSeason().getRankingLines();
+		}
+		return Collections.emptyList();
 	}
 }

--- a/src/test/java/com/lollito/fm/service/RankingServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/RankingServiceTest.java
@@ -1,0 +1,69 @@
+package com.lollito.fm.service;
+
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Ranking;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.Season;
+
+@ExtendWith(MockitoExtension.class)
+public class RankingServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    @Test
+    public void testLoadWithUserNoClub() {
+        // Mock user with no club
+        User user = new User();
+        user.setClub(null);
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        // Execute
+        List<Ranking> rankings = rankingService.load();
+
+        // Verify
+        assertNotNull(rankings);
+        assertEquals(0, rankings.size());
+    }
+
+    @Test
+    public void testLoadWithUserAndClub() {
+        // Mock user with club
+        User user = new User();
+        Club club = new Club();
+        League league = new League();
+        Season season = new Season();
+        Ranking ranking = new Ranking();
+
+        season.setRankingLines(Collections.singletonList(ranking));
+        league.setCurrentSeason(season);
+        club.setLeague(league);
+        user.setClub(club);
+
+        when(userService.getLoggedUser()).thenReturn(user);
+
+        // Execute
+        List<Ranking> rankings = rankingService.load();
+
+        // Verify
+        assertNotNull(rankings);
+        assertEquals(1, rankings.size());
+    }
+}


### PR DESCRIPTION
Fixed a `NullPointerException` in `RankingService.load()` that occurred when the logged-in user did not have an associated club (e.g., admin users or users with unassigned clubs). The method now returns an empty list in such cases instead of crashing. Added a new test `RankingServiceTest` to verify the fix.

---
*PR created automatically by Jules for task [18109186646767757792](https://jules.google.com/task/18109186646767757792) started by @lollito*