### PR TITLE
Refactor scheduled tasks to use configurable properties and improve logging for debugging

### DIFF
--- a/src/main/java/com/lollito/fm/ScheduledTasks.java
+++ b/src/main/java/com/lollito/fm/ScheduledTasks.java
@@ -1,7 +1,6 @@
 package com.lollito.fm;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -9,15 +8,15 @@ import org.springframework.stereotype.Component;
 import com.lollito.fm.service.ServerService;
 
 @Component
+@Slf4j
 public class ScheduledTasks {
 
-	private final Logger logger = LoggerFactory.getLogger(this.getClass());
-	
 	@Autowired private ServerService serverService;
 	
-    @Scheduled(cron = "0 0 1 * * ?")
+    @Scheduled(initialDelayString = "${fm.scheduling.general.initial-delay}", fixedRateString = "${fm.scheduling.general.fixed-rate}")
     public void deleteAllServers() {
-	logger.info("Deleting all servers");
-	serverService.deleteAll();
+        log.info("Starting deleteAllServers...");
+	    serverService.deleteAll();
+        log.info("Finished deleteAllServers.");
     }
 }

--- a/src/main/java/com/lollito/fm/service/InfrastructureService.java
+++ b/src/main/java/com/lollito/fm/service/InfrastructureService.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ import com.lollito.fm.repository.rest.YouthAcademyRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
+@Slf4j
 public class InfrastructureService {
 
     @Autowired
@@ -389,14 +391,16 @@ public class InfrastructureService {
         youthAcademyRepository.save(facility);
     }
 
-    @Scheduled(cron = "0 0 10 1 * *")
+    @Scheduled(initialDelayString = "${fm.scheduling.infrastructure.initial-delay}", fixedRateString = "${fm.scheduling.infrastructure.fixed-rate}")
     @Transactional
     public void processMonthlyMaintenance() {
+        log.info("Starting processMonthlyMaintenance...");
         List<Club> allClubs = clubService.findAll();
 
         for (Club club : allClubs) {
             processClubMaintenance(club);
         }
+        log.info("Finished processMonthlyMaintenance.");
     }
 
     private void processClubMaintenance(Club club) {

--- a/src/main/java/com/lollito/fm/service/InjuryService.java
+++ b/src/main/java/com/lollito/fm/service/InjuryService.java
@@ -5,8 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -26,9 +25,8 @@ import com.lollito.fm.repository.rest.PlayerRepository;
 import com.lollito.fm.utils.RandomUtils;
 
 @Service
+@Slf4j
 public class InjuryService {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     private InjuryRepository injuryRepository;
@@ -132,8 +130,9 @@ public class InjuryService {
         return injuryRepository.save(injury);
     }
 
-    @Scheduled(cron = "0 0 6 * * *") // Daily at 6 AM
+    @Scheduled(initialDelayString = "${fm.scheduling.injury.initial-delay}", fixedRateString = "${fm.scheduling.injury.fixed-rate}")
     public void processInjuryRecovery() {
+        log.info("Starting processInjuryRecovery...");
         List<Injury> activeInjuries = injuryRepository.findByStatus(InjuryStatus.ACTIVE);
 
         for (Injury injury : activeInjuries) {
@@ -144,10 +143,11 @@ public class InjuryService {
                     injury.setActualRecoveryDate(LocalDate.now());
                     injuryRepository.save(injury);
 
-                    logger.info("Player {} {} recovered from {}", injury.getPlayer().getName(), injury.getPlayer().getSurname(), injury.getType());
+                    log.info("Player {} {} recovered from {}", injury.getPlayer().getName(), injury.getPlayer().getSurname(), injury.getType());
                 }
             }
         }
+        log.info("Finished processInjuryRecovery.");
     }
 
     public List<Injury> getTeamInjuries(Long teamId) {

--- a/src/main/java/com/lollito/fm/service/LiveMatchService.java
+++ b/src/main/java/com/lollito/fm/service/LiveMatchService.java
@@ -8,8 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -33,9 +32,8 @@ import com.lollito.fm.repository.rest.MatchRepository;
 import lombok.Data;
 
 @Service
+@Slf4j
 public class LiveMatchService {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired private LiveMatchSessionRepository liveMatchSessionRepository;
     @Autowired private MatchRepository matchRepository;
@@ -66,14 +64,14 @@ public class LiveMatchService {
                     .build();
 
             liveMatchSessionRepository.save(session);
-            logger.info("Created LiveMatchSession for match {}", match.getId());
+            log.info("Created LiveMatchSession for match {}", match.getId());
         } catch (Exception e) {
-            logger.error("Error creating live match session", e);
+            log.error("Error creating live match session", e);
             throw new RuntimeException(e);
         }
     }
 
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(initialDelayString = "${fm.scheduling.live-match.initial-delay}", fixedRateString = "${fm.scheduling.live-match.fixed-rate}")
     @Transactional
     public void updateLiveMatches() {
         List<LiveMatchSession> sessions = liveMatchSessionRepository.findByFinishedFalse();
@@ -102,7 +100,7 @@ public class LiveMatchService {
                     finishMatch(session);
                 }
             } catch (Exception e) {
-                logger.error("Error updating session {}", session.getId(), e);
+                log.error("Error updating session {}", session.getId(), e);
             }
         }
     }

--- a/src/main/java/com/lollito/fm/service/MatchSchedulerService.java
+++ b/src/main/java/com/lollito/fm/service/MatchSchedulerService.java
@@ -3,8 +3,7 @@ package com.lollito.fm.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -14,23 +13,24 @@ import com.lollito.fm.model.MatchStatus;
 import com.lollito.fm.repository.rest.MatchRepository;
 
 @Service
+@Slf4j
 public class MatchSchedulerService {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired private MatchRepository matchRepository;
     @Autowired private MatchProcessor matchProcessor;
 
-    @Scheduled(cron = "${fm.match.processing.cron:0 * * * * *}")
+    @Scheduled(initialDelayString = "${fm.scheduling.match-processing.initial-delay}", fixedRateString = "${fm.scheduling.match-processing.fixed-rate}")
     public void processScheduledMatches() {
+        log.info("Starting processScheduledMatches...");
         LocalDateTime now = LocalDateTime.now();
         List<Match> matchesToRun = matchRepository.findByStatusAndDateBefore(MatchStatus.SCHEDULED, now);
 
         if (!matchesToRun.isEmpty()) {
-            logger.info("Found {} matches to run.", matchesToRun.size());
+            log.info("Found {} matches to run.", matchesToRun.size());
             for (Match match : matchesToRun) {
                 matchProcessor.processMatch(match.getId());
             }
         }
+        log.info("Finished processScheduledMatches.");
     }
 }

--- a/src/main/java/com/lollito/fm/service/ScoutingService.java
+++ b/src/main/java/com/lollito/fm/service/ScoutingService.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,9 +38,8 @@ import com.lollito.fm.utils.RandomUtils;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
+@Slf4j
 public class ScoutingService {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired private ScoutRepository scoutRepository;
     @Autowired private ScoutingAssignmentRepository assignmentRepository;
@@ -113,15 +111,17 @@ public class ScoutingService {
         return scout.getStatus() == ScoutStatus.ACTIVE;
     }
 
-    @Scheduled(cron = "0 0 9 * * *")
+    @Scheduled(initialDelayString = "${fm.scheduling.scouting.initial-delay}", fixedRateString = "${fm.scheduling.scouting.fixed-rate}")
     @Transactional
     public void processDailyScoutingProgress() {
+        log.info("Starting processDailyScoutingProgress...");
         List<ScoutingAssignment> activeAssignments = assignmentRepository
             .findAllWithScoutAndPlayerAndClub(AssignmentStatus.IN_PROGRESS);
 
         for (ScoutingAssignment assignment : activeAssignments) {
             processScoutingProgress(assignment);
         }
+        log.info("Finished processDailyScoutingProgress.");
     }
 
     private void processScoutingProgress(ScoutingAssignment assignment) {

--- a/src/main/java/com/lollito/fm/service/SponsorshipService.java
+++ b/src/main/java/com/lollito/fm/service/SponsorshipService.java
@@ -6,8 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -50,9 +49,8 @@ import com.lollito.fm.repository.rest.SponsorshipPaymentRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
+@Slf4j
 public class SponsorshipService {
-
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     private SponsorRepository sponsorRepository;
@@ -374,9 +372,10 @@ public class SponsorshipService {
     /**
      * Process monthly sponsorship payments
      */
-    @Scheduled(cron = "0 0 9 1 * *") // First day of month at 9 AM
+    @Scheduled(initialDelayString = "${fm.scheduling.sponsorship.initial-delay}", fixedRateString = "${fm.scheduling.sponsorship.fixed-rate}")
     @Transactional
     public void processMonthlyPayments() {
+        log.info("Starting processMonthlyPayments...");
         LocalDate today = LocalDate.now();
 
         // Get all pending payments due today or overdue
@@ -398,6 +397,7 @@ public class SponsorshipService {
 
         // Generate next month payments for active deals
         generateNextMonthPayments();
+        log.info("Finished processMonthlyPayments.");
     }
 
     private void generateNextMonthPayments() {

--- a/src/main/java/com/lollito/fm/service/StaffService.java
+++ b/src/main/java/com/lollito/fm/service/StaffService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +32,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 
 @Service
+@Slf4j
 public class StaffService {
 
     @Autowired
@@ -312,9 +314,10 @@ public class StaffService {
             .build();
     }
 
-    @Scheduled(cron = "${fm.staff.salary.processing.cron:0 0 8 1 * *}")
+    @Scheduled(initialDelayString = "${fm.scheduling.staff.initial-delay}", fixedRateString = "${fm.scheduling.staff.fixed-rate}")
     @Transactional
     public void processMonthlyStaffSalaries() {
+        log.info("Starting processMonthlyStaffSalaries...");
         List<Staff> activeStaff = staffRepository.findByStatus(StaffStatus.ACTIVE);
 
         for (Staff staff : activeStaff) {
@@ -329,6 +332,7 @@ public class StaffService {
                 }
             }
         }
+        log.info("Finished processMonthlyStaffSalaries.");
     }
 
     @Transactional

--- a/src/main/java/com/lollito/fm/service/TrainingService.java
+++ b/src/main/java/com/lollito/fm/service/TrainingService.java
@@ -6,8 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,9 +38,8 @@ import com.lollito.fm.repository.TrainingSessionRepository;
 import com.lollito.fm.repository.rest.ClubRepository;
 
 @Service
+@Slf4j
 public class TrainingService {
-
-    private static final Logger logger = LoggerFactory.getLogger(TrainingService.class);
 
     @Autowired
     private TrainingSessionRepository trainingSessionRepository;
@@ -70,9 +68,9 @@ public class TrainingService {
     /**
      * Process daily training for all teams
      */
-    @Scheduled(cron = "${fm.training.schedule.cron:0 0 10 * * MON-FRI}")
+    @Scheduled(initialDelayString = "${fm.scheduling.training.initial-delay}", fixedRateString = "${fm.scheduling.training.fixed-rate}")
     public void processDailyTraining() {
-        logger.info("Starting daily training processing");
+        log.info("Starting daily training processing");
         List<TrainingPlan> activePlans = trainingPlanRepository.findAll();
 
         for (TrainingPlan plan : activePlans) {
@@ -84,10 +82,10 @@ public class TrainingService {
                     }
                 }
             } catch (Exception e) {
-                logger.error("Error processing training for team {}", plan.getTeam().getId(), e);
+                log.error("Error processing training for team {}", plan.getTeam().getId(), e);
             }
         }
-        logger.info("Completed daily training processing");
+        log.info("Completed daily training processing");
     }
 
     private TrainingFocus getTodaysFocus(TrainingPlan plan) {

--- a/src/main/java/com/lollito/fm/service/WatchlistService.java
+++ b/src/main/java/com/lollito/fm/service/WatchlistService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -42,6 +43,7 @@ import com.lollito.fm.repository.WatchlistUpdateRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
+@Slf4j
 public class WatchlistService {
 
     @Autowired
@@ -186,13 +188,15 @@ public class WatchlistService {
     /**
      * Process daily watchlist updates
      */
-    @Scheduled(cron = "0 0 8 * * *") // Daily at 8 AM
+    @Scheduled(initialDelayString = "${fm.scheduling.watchlist.initial-delay}", fixedRateString = "${fm.scheduling.watchlist.fixed-rate}")
     public void processDailyWatchlistUpdates() {
+        log.info("Starting processDailyWatchlistUpdates...");
         List<WatchlistEntry> allEntries = watchlistEntryRepository.findAllActive();
 
         for (WatchlistEntry entry : allEntries) {
             processWatchlistEntryUpdates(entry);
         }
+        log.info("Finished processDailyWatchlistUpdates.");
     }
 
     /**

--- a/src/main/java/com/lollito/fm/service/YouthAcademyService.java
+++ b/src/main/java/com/lollito/fm/service/YouthAcademyService.java
@@ -4,8 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -29,9 +28,8 @@ import com.lollito.fm.utils.RandomUtils;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
+@Slf4j
 public class YouthAcademyService {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired private YouthAcademyRepository youthAcademyRepository;
     @Autowired private YouthCandidateRepository youthCandidateRepository;
@@ -46,10 +44,10 @@ public class YouthAcademyService {
     @Value("${fm.youth.quality.multiplier:1.0}")
     private Double qualityMultiplier;
 
-    @Scheduled(cron = "${fm.youth.generation.cron:0 0 12 * * MON}")
+    @Scheduled(initialDelayString = "${fm.scheduling.youth.initial-delay}", fixedRateString = "${fm.scheduling.youth.fixed-rate}")
     @Transactional
     public void generateYouthCandidates() {
-        logger.info("Starting scheduled youth candidate generation...");
+        log.info("Starting scheduled youth candidate generation...");
         List<YouthAcademy> academies = youthAcademyRepository.findAll();
 
         for (YouthAcademy academy : academies) {
@@ -64,10 +62,10 @@ public class YouthAcademyService {
                      createCandidate(academy);
                 }
             } catch (Exception e) {
-                logger.error("Error generating candidates for academy {}", academy.getId(), e);
+                log.error("Error generating candidates for academy {}", academy.getId(), e);
             }
         }
-        logger.info("Completed youth candidate generation.");
+        log.info("Completed youth candidate generation.");
     }
 
     private YouthCandidate createCandidate(YouthAcademy academy) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -125,3 +125,66 @@ fm.youth.quality.multiplier=1.0
 
 # Match Processing Configuration
 fm.match.processing.cron=0 * * * * *
+
+# Global scheduling configuration
+# All tasks start 3 minutes (180000ms) after boot and repeat every 1 minute (60000ms) for debug purposes
+
+# Loan Service
+fm.scheduling.loans.initial-delay=180000
+fm.scheduling.loans.fixed-rate=60000
+
+# Staff Service
+fm.scheduling.staff.initial-delay=180000
+fm.scheduling.staff.fixed-rate=60000
+
+# Scouting Service
+fm.scheduling.scouting.initial-delay=180000
+fm.scheduling.scouting.fixed-rate=60000
+
+# Training Service
+fm.scheduling.training.initial-delay=180000
+fm.scheduling.training.fixed-rate=60000
+
+# Watchlist Service
+fm.scheduling.watchlist.initial-delay=180000
+fm.scheduling.watchlist.fixed-rate=60000
+
+# Youth Academy Service
+fm.scheduling.youth.initial-delay=180000
+fm.scheduling.youth.fixed-rate=60000
+
+# Financial Service
+fm.scheduling.finance.initial-delay=180000
+fm.scheduling.finance.fixed-rate=60000
+
+# Injury Service
+fm.scheduling.injury.initial-delay=180000
+fm.scheduling.injury.fixed-rate=60000
+
+# Contract Service - Performance Bonuses
+fm.scheduling.contract.bonuses.initial-delay=180000
+fm.scheduling.contract.bonuses.fixed-rate=60000
+
+# Contract Service - Expiries
+fm.scheduling.contract.expiry.initial-delay=180000
+fm.scheduling.contract.expiry.fixed-rate=60000
+
+# Sponsorship Service
+fm.scheduling.sponsorship.initial-delay=180000
+fm.scheduling.sponsorship.fixed-rate=60000
+
+# Live Match Service
+fm.scheduling.live-match.initial-delay=180000
+fm.scheduling.live-match.fixed-rate=5000
+
+# Infrastructure Service
+fm.scheduling.infrastructure.initial-delay=180000
+fm.scheduling.infrastructure.fixed-rate=60000
+
+# Match Scheduler Service
+fm.scheduling.match-processing.initial-delay=180000
+fm.scheduling.match-processing.fixed-rate=60000
+
+# ScheduledTasks (General)
+fm.scheduling.general.initial-delay=180000
+fm.scheduling.general.fixed-rate=60000


### PR DESCRIPTION
Refactor scheduled tasks to use configurable properties and improve logging for debugging.

This change migrates all hardcoded `@Scheduled` cron and fixedRate values to `application.properties`, allowing for centralized configuration.
It sets a default `initialDelay` of 3 minutes for all tasks to ensure the server is fully initialized before background processing starts.
It also sets a default `fixedRate` of 1 minute (except for live matches) to facilitate easier debugging as requested.
Additionally, manual Logger instantiation has been replaced with Lombok's `@Slf4j` annotation across the modified services, and start/end logs have been added to scheduled methods.

---
*PR created automatically by Jules for task [5749208066224011813](https://jules.google.com/task/5749208066224011813) started by @lollito*