### PR TITLE
⚡ Bolt: Batch training updates

### DIFF
--- a/src/test/java/com/lollito/fm/service/TrainingServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/TrainingServiceTest.java
@@ -2,6 +2,7 @@ package com.lollito.fm.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -80,8 +81,11 @@ class TrainingServiceTest {
         assertThat(session.getFocus()).isEqualTo(TrainingFocus.ATTACKING);
         assertThat(session.getIntensity()).isEqualTo(TrainingIntensity.MODERATE);
 
-        verify(playerService).save(player);
-        verify(playerTrainingResultRepository).save(any());
+        verify(playerService).saveAll(any());
+        verify(playerService, times(0)).save(any());
+        verify(playerTrainingResultRepository, times(0)).save(any());
+
+        assertThat(session.getPlayerResults()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
💡 What: Optimized `TrainingService.processTeamTraining` to collect modified players and save them in a single batch using `playerService.saveAll`. Also removed individual `playerTrainingResultRepository.save` calls, relying on cascade persistence from the `TrainingSession` entity.

🎯 Why: The previous implementation iterated over all players in a team (approx 25) and performed 2 database saves per player (one for player, one for result), leading to 50+ database roundtrips per team per day. This caused significant latency during daily processing.

📊 Impact: Reduces database calls for training processing by ~95% (from ~52 calls per team to 3 calls).

🔬 Measurement: Verified by `TrainingServiceTest` which now confirms `playerService.saveAll` is called once instead of `playerService.save` multiple times.

---
*PR created automatically by Jules for task [12099250907041324626](https://jules.google.com/task/12099250907041324626) started by @lollito*