### PR TITLE
Add User Achievement Entities and Refactor Player Achievements

### DIFF
--- a/src/main/java/com/lollito/fm/model/AchievementType.java
+++ b/src/main/java/com/lollito/fm/model/AchievementType.java
@@ -1,19 +1,26 @@
 package com.lollito.fm.model;
 
+import lombok.Getter;
+
+@Getter
 public enum AchievementType {
-    MILESTONE("Milestone Achievement"),
-    PERFORMANCE("Performance Achievement"),
-    TEAM_SUCCESS("Team Success"),
-    INDIVIDUAL_AWARD("Individual Award"),
-    RECORD("Record Achievement");
+    WIN_LEAGUE("League Champion", "Win the league title", 1000),
+    WIN_CUP("Cup Winner", "Win the cup title", 500),
+    PROMOTION("Promotion", "Gain promotion to a higher league", 800),
+    TYCOON("Tycoon", "Accumulate a balance of 100M", 300),
+    SCROOGE("Scrooge", "Complete a season with zero spending", 200),
+    GOLEADOR("Goleador", "Win a match by 5 goals or more", 150),
+    COMEBACK_KING("Comeback King", "Win a match after being 0-2 down", 250),
+    ACADEMY_HERO("Academy Hero", "Have a youth academy graduate score a goal", 100),
+    TRADER("Trader", "Make a profit on a player sale", 100);
 
-    private final String displayName;
+    private final String name;
+    private final String description;
+    private final int xpReward;
 
-    AchievementType(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getDisplayName() {
-        return displayName;
+    AchievementType(String name, String description, int xpReward) {
+        this.name = name;
+        this.description = description;
+        this.xpReward = xpReward;
     }
 }

--- a/src/main/java/com/lollito/fm/model/PlayerAchievementType.java
+++ b/src/main/java/com/lollito/fm/model/PlayerAchievementType.java
@@ -1,0 +1,19 @@
+package com.lollito.fm.model;
+
+public enum PlayerAchievementType {
+    MILESTONE("Milestone Achievement"),
+    PERFORMANCE("Performance Achievement"),
+    TEAM_SUCCESS("Team Success"),
+    INDIVIDUAL_AWARD("Individual Award"),
+    RECORD("Record Achievement");
+
+    private final String displayName;
+
+    PlayerAchievementType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/lollito/fm/model/User.java
+++ b/src/main/java/com/lollito/fm/model/User.java
@@ -200,6 +200,10 @@ public class User implements Serializable {
 	
 	@Builder.Default
 	private double experience = 0; 
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	@Builder.Default
+	private List<UserAchievement> achievements = new ArrayList<>();
 	 
 	public User(String username, String name, String surname, String email, String password) {
 		this();

--- a/src/main/java/com/lollito/fm/model/UserAchievement.java
+++ b/src/main/java/com/lollito/fm/model/UserAchievement.java
@@ -1,40 +1,38 @@
 package com.lollito.fm.model;
 
 import java.io.Serializable;
-import java.time.LocalDate;
+import java.time.Instant;
 
 import org.hibernate.annotations.GenericGenerator;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @Entity
-@Table(name = "player_achievement")
-@Getter
-@Setter
+@Table(name = "user_achievement", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "achievement"})
+})
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
-public class PlayerAchievement implements Serializable {
+public class UserAchievement implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -44,28 +42,15 @@ public class PlayerAchievement implements Serializable {
     @EqualsAndHashCode.Include
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "player_id")
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
     @ToString.Exclude
-    @JsonIgnore
-    private Player player;
+    private User user;
 
     @Enumerated(EnumType.STRING)
-    private PlayerAchievementType type;
+    @EqualsAndHashCode.Include
+    private AchievementType achievement;
 
-    private String title;
-    private String description;
-    private LocalDate dateAchieved;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "season_id")
-    @ToString.Exclude
-    private Season season;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "club_id")
-    @ToString.Exclude
-    private Club club;
-
-    private String additionalData; // JSON for extra achievement data
+    @Builder.Default
+    private Instant unlockedAt = Instant.now();
 }

--- a/src/main/java/com/lollito/fm/model/rest/AddAchievementRequest.java
+++ b/src/main/java/com/lollito/fm/model/rest/AddAchievementRequest.java
@@ -1,6 +1,6 @@
 package com.lollito.fm.model.rest;
 
-import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.PlayerAchievementType;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AddAchievementRequest {
-    private AchievementType type;
+    private PlayerAchievementType type;
     private String title;
     private String description;
 }

--- a/src/main/java/com/lollito/fm/model/rest/PlayerAchievementDTO.java
+++ b/src/main/java/com/lollito/fm/model/rest/PlayerAchievementDTO.java
@@ -2,7 +2,7 @@ package com.lollito.fm.model.rest;
 
 import java.time.LocalDate;
 
-import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.PlayerAchievementType;
 import com.lollito.fm.model.dto.ClubDTO;
 import com.lollito.fm.model.dto.SeasonDTO;
 
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PlayerAchievementDTO {
     private Long id;
-    private AchievementType type;
+    private PlayerAchievementType type;
     private String title;
     private String description;
     private LocalDate dateAchieved;

--- a/src/main/java/com/lollito/fm/repository/UserAchievementRepository.java
+++ b/src/main/java/com/lollito/fm/repository/UserAchievementRepository.java
@@ -1,0 +1,17 @@
+package com.lollito.fm.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.UserAchievement;
+
+@Repository
+public interface UserAchievementRepository extends JpaRepository<UserAchievement, Long> {
+
+    boolean existsByUserIdAndAchievement(Long userId, AchievementType achievement);
+
+    List<UserAchievement> findByUserId(Long userId);
+}

--- a/src/main/java/com/lollito/fm/service/PlayerHistoryService.java
+++ b/src/main/java/com/lollito/fm/service/PlayerHistoryService.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.PlayerAchievementType;
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.MatchPlayerStats;
 import com.lollito.fm.model.Player;
@@ -242,14 +242,14 @@ public class PlayerHistoryService {
         return transfer;
     }
 
-    public PlayerAchievement addAchievement(Long playerId, AchievementType type,
+    public PlayerAchievement addAchievement(Long playerId, PlayerAchievementType type,
                                           String title, String description) {
         Player player = playerRepository.findById(playerId)
                 .orElseThrow(() -> new EntityNotFoundException("Player not found"));
         return addAchievement(player, type, title, description);
     }
 
-    public PlayerAchievement addAchievement(Player player, AchievementType type,
+    public PlayerAchievement addAchievement(Player player, PlayerAchievementType type,
                                           String title, String description) {
         Season currentSeason = seasonService.getCurrentSeason();
 
@@ -273,14 +273,14 @@ public class PlayerHistoryService {
         }
 
         if (player.getCareerStats().getFirstGoal() == null && matchStats.getGoals() > 0) {
-            addAchievement(player, AchievementType.MILESTONE, "First Goal",
+            addAchievement(player, PlayerAchievementType.MILESTONE, "First Goal",
                          "Scored first professional goal");
             player.getCareerStats().setFirstGoal(LocalDate.now());
             playerCareerStatsRepository.save(player.getCareerStats());
         }
 
         if (matchStats.getGoals() >= 3) {
-            addAchievement(player, AchievementType.PERFORMANCE, "Hat-trick",
+            addAchievement(player, PlayerAchievementType.PERFORMANCE, "Hat-trick",
                          "Scored 3 or more goals in a single match");
         }
 
@@ -292,14 +292,14 @@ public class PlayerHistoryService {
             // "totalGoals" is already updated in updateCareerStats.
             // If I had 9 goals, scored 2, now 11. 10 is missed.
             // But let's stick to task logic mostly.
-            addAchievement(player, AchievementType.MILESTONE,
+            addAchievement(player, PlayerAchievementType.MILESTONE,
                          totalGoals + " Career Goals",
                          "Reached " + totalGoals + " career goals");
         }
 
         int totalMatches = player.getCareerStats().getTotalMatchesPlayed();
         if (totalMatches == 50 || totalMatches == 100 || totalMatches == 200 || totalMatches == 500) {
-            addAchievement(player, AchievementType.MILESTONE,
+            addAchievement(player, PlayerAchievementType.MILESTONE,
                          totalMatches + " Career Matches",
                          "Played " + totalMatches + " professional matches");
 
@@ -310,14 +310,14 @@ public class PlayerHistoryService {
         }
 
         if (seasonStats.getGoals() == 20 || seasonStats.getGoals() == 30) {
-             addAchievement(player, AchievementType.PERFORMANCE,
+             addAchievement(player, PlayerAchievementType.PERFORMANCE,
                          seasonStats.getGoals() + " Goals in Season",
                          "Scored " + seasonStats.getGoals() + " goals in a single season");
         }
 
         if (player.getRole() == PlayerRole.GOALKEEPER && seasonStats.getCleanSheets() == 15) {
              // Use == 15 to avoid spamming every match after 15
-             addAchievement(player, AchievementType.PERFORMANCE,
+             addAchievement(player, PlayerAchievementType.PERFORMANCE,
                          "Clean Sheet Specialist",
                          "Kept " + seasonStats.getCleanSheets() + " clean sheets in a season");
         }


### PR DESCRIPTION
Implemented the database structure for tracking user achievements as per `gamification-tasks/3-achievements/1-achievement-entities.md`. This included refactoring the existing `AchievementType` (used for players) to `PlayerAchievementType` to allow for a clean `AchievementType` enum for users. Added `UserAchievement` entity and repository, and updated `User` entity to include the relationship. Verified with existing tests.

---
*PR created automatically by Jules for task [15673167739591910807](https://jules.google.com/task/15673167739591910807) started by @lollito*