### PR TITLE
Implement ManagerProgressionService

### DIFF
--- a/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
+++ b/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
@@ -1,0 +1,88 @@
+package com.lollito.fm.service;
+
+import com.lollito.fm.model.ManagerPerk;
+import com.lollito.fm.model.ManagerProfile;
+import com.lollito.fm.model.User;
+
+import java.util.HashSet;
+import com.lollito.fm.repository.ManagerProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ManagerProgressionService {
+
+    private final ManagerProfileRepository managerProfileRepository;
+
+    public static final long XP_WIN = 100;
+    public static final long XP_DRAW = 50;
+    public static final long XP_LOSS = 10;
+    public static final long LEVEL_XP_MULTIPLIER = 1000;
+
+    @Transactional
+    public ManagerProfile getProfile(User user) {
+        return managerProfileRepository.findByUserId(user.getId())
+                .orElseGet(() -> {
+                    ManagerProfile profile = ManagerProfile.builder()
+                            .user(user)
+                            .level(1)
+                            .currentXp(0L)
+                            .talentPoints(0)
+                            .unlockedPerks(new HashSet<>())
+                            .build();
+                    return managerProfileRepository.save(profile);
+                });
+    }
+
+    @Transactional
+    public void addXp(User user, long amount) {
+        ManagerProfile profile = getProfile(user);
+        profile.setCurrentXp(profile.getCurrentXp() + amount);
+
+        long xpForNextLevel = profile.getLevel() * LEVEL_XP_MULTIPLIER;
+        while (profile.getCurrentXp() >= xpForNextLevel) {
+            profile.setCurrentXp(profile.getCurrentXp() - xpForNextLevel);
+            profile.setLevel(profile.getLevel() + 1);
+            profile.setTalentPoints(profile.getTalentPoints() + 1);
+            log.info("Manager {} leveled up to level {}", user.getUsername(), profile.getLevel());
+
+            xpForNextLevel = profile.getLevel() * LEVEL_XP_MULTIPLIER;
+        }
+
+        managerProfileRepository.save(profile);
+    }
+
+    @Transactional
+    public void unlockPerk(User user, ManagerPerk perk) {
+        ManagerProfile profile = getProfile(user);
+
+        if (profile.getUnlockedPerks().contains(perk)) {
+            log.info("Manager {} already has perk {}", user.getUsername(), perk.getName());
+            return;
+        }
+
+        if (profile.getLevel() < perk.getRequiredLevel()) {
+            throw new IllegalArgumentException("Manager level " + profile.getLevel() + " is not high enough for perk " + perk.getName() + " (requires " + perk.getRequiredLevel() + ")");
+        }
+
+        if (profile.getTalentPoints() < 1) {
+            throw new IllegalArgumentException("Not enough talent points to unlock perk " + perk.getName());
+        }
+
+        profile.setTalentPoints(profile.getTalentPoints() - 1);
+        profile.getUnlockedPerks().add(perk);
+        managerProfileRepository.save(profile);
+        log.info("Manager {} unlocked perk {}", user.getUsername(), perk.getName());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasPerk(User user, ManagerPerk perk) {
+        return managerProfileRepository.findByUserId(user.getId())
+                .map(profile -> profile.getUnlockedPerks().contains(perk))
+                .orElse(false);
+    }
+}

--- a/src/test/java/com/lollito/fm/service/ManagerProgressionServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ManagerProgressionServiceTest.java
@@ -1,0 +1,206 @@
+package com.lollito.fm.service;
+
+import com.lollito.fm.model.ManagerPerk;
+import com.lollito.fm.model.ManagerProfile;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.ManagerProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManagerProgressionServiceTest {
+
+    @Mock
+    private ManagerProfileRepository managerProfileRepository;
+
+    @InjectMocks
+    private ManagerProgressionService managerProgressionService;
+
+    private User user;
+    private ManagerProfile profile;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setUsername("manager1");
+
+        profile = ManagerProfile.builder()
+                .id(1L)
+                .user(user)
+                .level(1)
+                .currentXp(0L)
+                .talentPoints(0)
+                .unlockedPerks(new HashSet<>())
+                .build();
+    }
+
+    @Test
+    void getProfile_ShouldCreateNewProfile_WhenNoneExists() {
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(managerProfileRepository.save(any(ManagerProfile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ManagerProfile result = managerProgressionService.getProfile(user);
+
+        assertNotNull(result);
+        assertEquals(user, result.getUser());
+        assertEquals(1, result.getLevel());
+        assertEquals(0L, result.getCurrentXp());
+        assertEquals(0, result.getTalentPoints());
+        assertNotNull(result.getUnlockedPerks());
+        assertTrue(result.getUnlockedPerks().isEmpty());
+
+        verify(managerProfileRepository).save(any(ManagerProfile.class));
+    }
+
+    @Test
+    void getProfile_ShouldReturnExistingProfile_WhenExists() {
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        ManagerProfile result = managerProgressionService.getProfile(user);
+
+        assertEquals(profile, result);
+        verify(managerProfileRepository, never()).save(any(ManagerProfile.class));
+    }
+
+    @Test
+    void addXp_ShouldIncrementXp_WhenNoLevelUp() {
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        managerProgressionService.addXp(user, 500L);
+
+        assertEquals(500L, profile.getCurrentXp());
+        assertEquals(1, profile.getLevel());
+        assertEquals(0, profile.getTalentPoints());
+        verify(managerProfileRepository).save(profile);
+    }
+
+    @Test
+    void addXp_ShouldLevelUp_WhenThresholdReached() {
+        // Threshold for level 1 is 1000
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        managerProgressionService.addXp(user, 1200L);
+
+        // 1200 XP -> Level up -> 1200 - 1000 = 200 XP left
+        // Level becomes 2
+        // Talent points becomes 1
+
+        assertEquals(200L, profile.getCurrentXp());
+        assertEquals(2, profile.getLevel());
+        assertEquals(1, profile.getTalentPoints());
+        verify(managerProfileRepository).save(profile);
+    }
+
+    @Test
+    void addXp_ShouldHandleMultipleLevelUps() {
+        // Threshold for level 1: 1000
+        // Threshold for level 2: 2000
+        // Total needed for level 3: 3000
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        managerProgressionService.addXp(user, 3500L);
+
+        // 3500 >= 1000 -> Level 2, XP 2500, TP 1
+        // 2500 >= 2000 -> Level 3, XP 500, TP 2
+
+        assertEquals(500L, profile.getCurrentXp());
+        assertEquals(3, profile.getLevel());
+        assertEquals(2, profile.getTalentPoints());
+        verify(managerProfileRepository).save(profile);
+    }
+
+    @Test
+    void unlockPerk_ShouldUnlockPerk_WhenRequirementsMet() {
+        // Set up profile to meet requirements for a perk
+        // e.g. VIDEO_ANALYST requires level 1
+        profile.setLevel(1);
+        profile.setTalentPoints(1);
+
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        managerProgressionService.unlockPerk(user, ManagerPerk.VIDEO_ANALYST);
+
+        assertTrue(profile.getUnlockedPerks().contains(ManagerPerk.VIDEO_ANALYST));
+        assertEquals(0, profile.getTalentPoints());
+        verify(managerProfileRepository).save(profile);
+    }
+
+    @Test
+    void unlockPerk_ShouldThrowException_WhenLevelTooLow() {
+        // MOTIVATOR requires level 5
+        profile.setLevel(1);
+        profile.setTalentPoints(10);
+
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        assertThrows(IllegalArgumentException.class, () ->
+            managerProgressionService.unlockPerk(user, ManagerPerk.MOTIVATOR)
+        );
+
+        verify(managerProfileRepository, never()).save(profile);
+    }
+
+    @Test
+    void unlockPerk_ShouldThrowException_WhenNotEnoughPoints() {
+        // VIDEO_ANALYST requires level 1
+        profile.setLevel(1);
+        profile.setTalentPoints(0);
+
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        assertThrows(IllegalArgumentException.class, () ->
+            managerProgressionService.unlockPerk(user, ManagerPerk.VIDEO_ANALYST)
+        );
+
+        verify(managerProfileRepository, never()).save(profile);
+    }
+
+    @Test
+    void unlockPerk_ShouldDoNothing_WhenAlreadyUnlocked() {
+        profile.setLevel(5);
+        profile.setTalentPoints(10);
+        profile.getUnlockedPerks().add(ManagerPerk.VIDEO_ANALYST);
+
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        managerProgressionService.unlockPerk(user, ManagerPerk.VIDEO_ANALYST);
+
+        // Should not deduct points
+        assertEquals(10, profile.getTalentPoints());
+        verify(managerProfileRepository, never()).save(profile);
+    }
+
+    @Test
+    void hasPerk_ShouldReturnTrue_WhenPerkIsUnlocked() {
+        profile.getUnlockedPerks().add(ManagerPerk.VIDEO_ANALYST);
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        assertTrue(managerProgressionService.hasPerk(user, ManagerPerk.VIDEO_ANALYST));
+    }
+
+    @Test
+    void hasPerk_ShouldReturnFalse_WhenPerkIsNotUnlocked() {
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.of(profile));
+
+        assertFalse(managerProgressionService.hasPerk(user, ManagerPerk.VIDEO_ANALYST));
+    }
+
+    @Test
+    void hasPerk_ShouldReturnFalse_WhenProfileDoesNotExist() {
+        when(managerProfileRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+
+        assertFalse(managerProgressionService.hasPerk(user, ManagerPerk.VIDEO_ANALYST));
+    }
+}


### PR DESCRIPTION
Implemented the business logic for manager progression as defined in `gamification-tasks/1-manager-progression/2-xp-service.md`.
The service handles:
- Retrieving or creating a manager profile.
- Adding XP and handling level-ups (recursive for multiple levels).
- Unlocking perks by checking level and talent point requirements.
- Helper method to check if a user has a perk.
- Constants for XP rewards (Win, Draw, Loss).

Unit tests cover all scenarios including edge cases for leveling and perk requirements.

---
*PR created automatically by Jules for task [3128294877437944507](https://jules.google.com/task/3128294877437944507) started by @lollito*