### PR TITLE
Implement Achievement Logic

### DIFF
--- a/src/main/java/com/lollito/fm/service/AchievementService.java
+++ b/src/main/java/com/lollito/fm/service/AchievementService.java
@@ -1,0 +1,199 @@
+package com.lollito.fm.service;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.EventHistory;
+import com.lollito.fm.model.Finance;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.Ranking;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.UserAchievement;
+import com.lollito.fm.repository.UserAchievementRepository;
+
+@Service
+public class AchievementService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private UserAchievementRepository userAchievementRepository;
+
+    @Autowired
+    private ManagerProgressionService managerProgressionService;
+
+    // FinancialService might be needed if we need to fetch finance, but we can pass Finance object
+    @Autowired
+    private FinancialService financialService;
+
+    @Transactional
+    public void checkAndUnlock(User user, AchievementType achievement) {
+        if (user == null || achievement == null) {
+            return;
+        }
+
+        if (userAchievementRepository.existsByUserIdAndAchievement(user.getId(), achievement)) {
+            return;
+        }
+
+        UserAchievement userAchievement = UserAchievement.builder()
+                .user(user)
+                .achievement(achievement)
+                .build();
+
+        userAchievementRepository.save(userAchievement);
+
+        managerProgressionService.addXp(user, achievement.getXpReward());
+
+        logger.info("Achievement Unlocked: {} for User {}", achievement.getName(), user.getUsername());
+        // TODO: Publish AchievementUnlockedEvent if needed
+    }
+
+    @Transactional
+    public void checkMatchAchievements(Match match) {
+        if (match == null || match.getHome() == null || match.getAway() == null) {
+            return;
+        }
+
+        checkGoleador(match);
+        checkComebackKing(match);
+    }
+
+    private void checkGoleador(Match match) {
+        // Goleador: Win by 5 goals or more (or score >= 5 depending on interpretation, sticking to score >= 5 as per task)
+        // Task says: Check match.getScoreHome() >= 5 -> checkAndUnlock(user, GOLEADOR)
+
+        if (match.getHomeScore() >= 5) {
+            User user = match.getHome().getUser();
+            if (user != null) {
+                checkAndUnlock(user, AchievementType.GOLEADOR);
+            }
+        }
+
+        if (match.getAwayScore() >= 5) {
+            User user = match.getAway().getUser();
+            if (user != null) {
+                checkAndUnlock(user, AchievementType.GOLEADOR);
+            }
+        }
+    }
+
+    private void checkComebackKing(Match match) {
+        // Comeback King: Win a match after being 0-2 down
+
+        User homeUser = match.getHome().getUser();
+        User awayUser = match.getAway().getUser();
+
+        if (homeUser == null && awayUser == null) {
+            return;
+        }
+
+        boolean homeWon = match.getHomeScore() > match.getAwayScore();
+        boolean awayWon = match.getAwayScore() > match.getHomeScore();
+
+        if (!homeWon && !awayWon) return; // Draw
+
+        List<EventHistory> events = match.getEvents();
+        if (events == null || events.isEmpty()) return;
+
+        // Replay score history
+        // Note: EventHistory stores current score at that event? No, it has homeScore and awayScore fields sometimes.
+        // Let's check EventHistory model or usage in SimulationMatchService.
+        // In SimulationMatchService: events.add(new EventHistory(..., homeScore, awayScore));
+        // So we can track score progression.
+
+        boolean homeWasDownByTwo = false;
+        boolean awayWasDownByTwo = false;
+
+        // Sort events by minute just in case
+        events.sort(Comparator.comparingInt(EventHistory::getMinute));
+
+        for (EventHistory event : events) {
+            if (event.getHomeScore() != null && event.getAwayScore() != null) {
+                int scoreDiff = event.getHomeScore() - event.getAwayScore();
+
+                if (scoreDiff <= -2) {
+                    homeWasDownByTwo = true;
+                }
+                if (scoreDiff >= 2) {
+                    awayWasDownByTwo = true;
+                }
+            }
+        }
+
+        if (homeWon && homeWasDownByTwo && homeUser != null) {
+            checkAndUnlock(homeUser, AchievementType.COMEBACK_KING);
+        }
+
+        if (awayWon && awayWasDownByTwo && awayUser != null) {
+            checkAndUnlock(awayUser, AchievementType.COMEBACK_KING);
+        }
+    }
+
+    @Transactional
+    public void checkSeasonAchievements(Season season) {
+        if (season == null) return;
+
+        List<Ranking> rankings = season.getRankingLines();
+        if (rankings == null || rankings.isEmpty()) return;
+
+        // Sort rankings
+        List<Ranking> sortedRankings = rankings.stream()
+            .sorted(Comparator.comparing(Ranking::getPoints).reversed()
+                .thenComparing(Comparator.comparingInt((Ranking r) -> r.getGoalsFor() - r.getGoalAgainst()).reversed()) // Goal Diff
+                .thenComparing(Comparator.comparing(Ranking::getGoalsFor).reversed())) // Goals For
+            .collect(Collectors.toList());
+
+        for (int i = 0; i < sortedRankings.size(); i++) {
+            Ranking ranking = sortedRankings.get(i);
+            Club club = ranking.getClub();
+            User user = club.getUser();
+
+            if (user != null) {
+                // Win League
+                if (i == 0) {
+                    checkAndUnlock(user, AchievementType.WIN_LEAGUE);
+                }
+
+                // Promotion
+                Integer promotionCount = season.getLeague().getPromotion();
+                if (promotionCount != null && i < promotionCount) {
+                     checkAndUnlock(user, AchievementType.PROMOTION);
+                }
+            }
+        }
+    }
+
+    @Transactional
+    public void checkFinancialAchievements(Finance finance) {
+        if (finance == null || finance.getClub() == null || finance.getClub().getUser() == null) {
+            return;
+        }
+
+        User user = finance.getClub().getUser();
+        BigDecimal balance = finance.getBalance();
+
+        // Tycoon: Accumulate a balance of 100M
+        if (balance.compareTo(BigDecimal.valueOf(100_000_000)) >= 0) {
+            checkAndUnlock(user, AchievementType.TYCOON);
+        }
+    }
+
+    // Additional Helper for direct User check
+    public void checkTycoon(User user) {
+        if(user.getClub() != null && user.getClub().getFinance() != null) {
+            checkFinancialAchievements(user.getClub().getFinance());
+        }
+    }
+}

--- a/src/main/java/com/lollito/fm/service/FinancialService.java
+++ b/src/main/java/com/lollito/fm/service/FinancialService.java
@@ -69,6 +69,9 @@ public class FinancialService {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private AchievementService achievementService;
+
     @Transactional
     public FinancialTransaction processTransaction(Long clubId, CreateTransactionRequest request) {
         Club club = clubService.findById(clubId);
@@ -120,6 +123,9 @@ public class FinancialService {
         // Check for financial alerts
         checkFinancialAlerts(finance);
 
+        // Check for achievements
+        achievementService.checkFinancialAchievements(finance);
+
         return transaction;
     }
 
@@ -166,6 +172,8 @@ public class FinancialService {
         // Update financial health indicators
         updateFinancialHealthIndicators(finance);
         financeRepository.save(finance);
+
+        achievementService.checkFinancialAchievements(finance);
     }
 
     private void processPlayerSalaries(Club club) {

--- a/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
+++ b/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
@@ -1,0 +1,101 @@
+package com.lollito.fm.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lollito.fm.model.ManagerPerk;
+import com.lollito.fm.model.ManagerProfile;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.ManagerProfileRepository;
+
+@Service
+public class ManagerProgressionService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private ManagerProfileRepository managerProfileRepository;
+
+    @Transactional
+    public ManagerProfile getProfile(User user) {
+        return managerProfileRepository.findByUserId(user.getId())
+                .orElseGet(() -> createProfile(user));
+    }
+
+    private ManagerProfile createProfile(User user) {
+        ManagerProfile profile = ManagerProfile.builder()
+                .user(user)
+                .level(1)
+                .currentXp(0L)
+                .talentPoints(0)
+                .build();
+        return managerProfileRepository.save(profile);
+    }
+
+    @Transactional
+    public void addXp(User user, long amount) {
+        ManagerProfile profile = getProfile(user);
+
+        long currentXp = profile.getCurrentXp() != null ? profile.getCurrentXp() : 0L;
+        profile.setCurrentXp(currentXp + amount);
+
+        checkLevelUp(profile);
+        managerProfileRepository.save(profile);
+    }
+
+    private void checkLevelUp(ManagerProfile profile) {
+        int level = profile.getLevel() != null ? profile.getLevel() : 1;
+        long xpNeeded = xpForNextLevel(level);
+
+        long currentXp = profile.getCurrentXp() != null ? profile.getCurrentXp() : 0L;
+
+        while (currentXp >= xpNeeded) {
+            currentXp -= xpNeeded;
+            level++;
+
+            Integer talentPoints = profile.getTalentPoints() != null ? profile.getTalentPoints() : 0;
+            profile.setTalentPoints(talentPoints + 1);
+
+            logger.info("User {} leveled up to level {}", profile.getUser().getUsername(), level);
+            xpNeeded = xpForNextLevel(level);
+        }
+
+        profile.setLevel(level);
+        profile.setCurrentXp(currentXp);
+    }
+
+    private long xpForNextLevel(int currentLevel) {
+        // Simple formula: Level * 1000
+        return currentLevel * 1000L;
+    }
+
+    @Transactional
+    public void unlockPerk(User user, ManagerPerk perk) {
+        ManagerProfile profile = getProfile(user);
+        if (hasPerk(user, perk)) {
+            logger.info("User {} already has perk {}", user.getUsername(), perk);
+            return;
+        }
+
+        // Basic validation logic
+        Integer talentPoints = profile.getTalentPoints() != null ? profile.getTalentPoints() : 0;
+
+        if (talentPoints > 0) {
+            profile.setTalentPoints(talentPoints - 1);
+            profile.getUnlockedPerks().add(perk);
+            managerProfileRepository.save(profile);
+            logger.info("User {} unlocked perk {}", user.getUsername(), perk);
+        } else {
+            logger.warn("User {} does not have enough talent points to unlock {}", user.getUsername(), perk);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasPerk(User user, ManagerPerk perk) {
+        ManagerProfile profile = getProfile(user);
+        return profile.getUnlockedPerks().contains(perk);
+    }
+}

--- a/src/main/java/com/lollito/fm/service/SeasonService.java
+++ b/src/main/java/com/lollito/fm/service/SeasonService.java
@@ -30,11 +30,15 @@ public class SeasonService {
 	@Autowired RankingService rankingService;
 	@Autowired SimulationMatchService simulationMatchService;
 	@Autowired LeagueService leagueService;
+	@Autowired AchievementService achievementService;
 	
 	public Season create(League league, LocalDateTime startDate) {
 		// Deactivate previous current season
 		List<Season> currentSeasons = seasonRepository.findAllByCurrentTrue();
 		for (Season s : currentSeasons) {
+			// Check achievements for the ending season
+			achievementService.checkSeasonAchievements(s);
+
 			s.setCurrent(false);
 			seasonRepository.save(s);
 		}

--- a/src/main/java/com/lollito/fm/service/SimulationMatchService.java
+++ b/src/main/java/com/lollito/fm/service/SimulationMatchService.java
@@ -48,6 +48,7 @@ public class SimulationMatchService {
 	@Autowired PlayerRepository playerRepository;
 	@Autowired PlayerHistoryService playerHistoryService;
 	@Autowired InjuryService injuryService;
+	@Autowired AchievementService achievementService;
 	
 	public void simulate(List<Match> matches){
 		List<Player> allPlayersToSave = new ArrayList<>();
@@ -64,6 +65,8 @@ public class SimulationMatchService {
 		playerService.saveAll(allPlayersToSave);
 		matchRepository.saveAll(matches);
 		rankingService.updateAll(matches);
+
+		matches.forEach(match -> achievementService.checkMatchAchievements(match));
 	}
 	
 	public MatchResult simulate(Match match) {
@@ -96,6 +99,8 @@ public class SimulationMatchService {
 		if (updateRanking) {
 			rankingService.update(match);
 		}
+
+		achievementService.checkMatchAchievements(match);
 
 		return MatchResult.builder()
 				.matchId(match.getId())

--- a/src/test/java/com/lollito/fm/service/AchievementServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/AchievementServiceTest.java
@@ -1,0 +1,187 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.AchievementType;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.EventHistory;
+import com.lollito.fm.model.Finance;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.Ranking;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.model.League;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.UserAchievement;
+import com.lollito.fm.repository.UserAchievementRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class AchievementServiceTest {
+
+    @Mock
+    private UserAchievementRepository userAchievementRepository;
+
+    @Mock
+    private ManagerProgressionService managerProgressionService;
+
+    @Mock
+    private FinancialService financialService;
+
+    @InjectMocks
+    private AchievementService achievementService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setUsername("testUser");
+    }
+
+    @Test
+    void checkAndUnlock_NewAchievement_ShouldUnlock() {
+        AchievementType achievement = AchievementType.GOLEADOR;
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), achievement)).thenReturn(false);
+
+        achievementService.checkAndUnlock(user, achievement);
+
+        verify(userAchievementRepository, times(1)).save(any(UserAchievement.class));
+        verify(managerProgressionService, times(1)).addXp(eq(user), eq((long) achievement.getXpReward()));
+    }
+
+    @Test
+    void checkAndUnlock_ExistingAchievement_ShouldNotUnlock() {
+        AchievementType achievement = AchievementType.GOLEADOR;
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), achievement)).thenReturn(true);
+
+        achievementService.checkAndUnlock(user, achievement);
+
+        verify(userAchievementRepository, never()).save(any(UserAchievement.class));
+        verify(managerProgressionService, never()).addXp(any(), any(Long.class));
+    }
+
+    @Test
+    void checkMatchAchievements_Goleador_HomeWin() {
+        Match match = new Match();
+        match.setHomeScore(5);
+        match.setAwayScore(0);
+
+        Club homeClub = new Club();
+        homeClub.setUser(user);
+        match.setHome(homeClub);
+
+        Club awayClub = new Club();
+        match.setAway(awayClub);
+
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), AchievementType.GOLEADOR)).thenReturn(false);
+
+        achievementService.checkMatchAchievements(match);
+
+        verify(userAchievementRepository, times(1)).save(any(UserAchievement.class));
+    }
+
+    @Test
+    void checkMatchAchievements_ComebackKing_HomeWin() {
+        Match match = new Match();
+        match.setHomeScore(3);
+        match.setAwayScore(2);
+
+        Club homeClub = new Club();
+        homeClub.setUser(user);
+        match.setHome(homeClub);
+
+        Club awayClub = new Club();
+        match.setAway(awayClub);
+
+        List<EventHistory> events = new ArrayList<>();
+        // 0-1
+        events.add(EventHistory.builder().homeScore(0).awayScore(1).minute(10).build());
+        // 0-2 (Down by 2)
+        events.add(EventHistory.builder().homeScore(0).awayScore(2).minute(20).build());
+        // 1-2
+        events.add(EventHistory.builder().homeScore(1).awayScore(2).minute(50).build());
+        // 2-2
+        events.add(EventHistory.builder().homeScore(2).awayScore(2).minute(70).build());
+        // 3-2
+        events.add(EventHistory.builder().homeScore(3).awayScore(2).minute(85).build());
+
+        match.setEvents(events);
+
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), AchievementType.COMEBACK_KING)).thenReturn(false);
+
+        achievementService.checkMatchAchievements(match);
+
+        verify(userAchievementRepository, times(1)).save(any(UserAchievement.class));
+    }
+
+    @Test
+    void checkFinancialAchievements_Tycoon_ShouldUnlock() {
+        Finance finance = new Finance();
+        finance.setBalance(new BigDecimal("100000000")); // 100M
+
+        Club club = new Club();
+        club.setUser(user);
+        finance.setClub(club);
+        // We need to set club on finance as well because checkFinancialAchievements uses finance.getClub()
+        // But finance doesn't store club directly in entity (mappedBy), but getter should exist or we mock.
+        // Wait, Finance entity has `private Club club` with `@OneToOne(mappedBy...)`.
+        // JPA populates it, but in test we need to set it.
+        // Finance entity doesn't have `setClub` in Lombok builder if not included?
+        // It has `@Setter`.
+        finance.setClub(club);
+
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), AchievementType.TYCOON)).thenReturn(false);
+
+        achievementService.checkFinancialAchievements(finance);
+
+        verify(userAchievementRepository, times(1)).save(any(UserAchievement.class));
+    }
+
+    @Test
+    void checkSeasonAchievements_WinLeague() {
+        Season season = new Season();
+        List<Ranking> rankings = new ArrayList<>();
+
+        Club userClub = new Club();
+        userClub.setUser(user);
+
+        Ranking r1 = new Ranking();
+        r1.setClub(userClub);
+        r1.setPoints(90);
+
+        Ranking r2 = new Ranking();
+        r2.setClub(new Club());
+        r2.setPoints(80);
+
+        rankings.add(r1);
+        rankings.add(r2);
+        season.setRankingLines(rankings);
+
+        // Mock League for promotion check
+        League league = new League();
+        league.setPromotion(0); // No promotion to avoid confusing test
+        season.setLeague(league);
+
+        when(userAchievementRepository.existsByUserIdAndAchievement(user.getId(), AchievementType.WIN_LEAGUE)).thenReturn(false);
+
+        achievementService.checkSeasonAchievements(season);
+
+        verify(userAchievementRepository, times(1)).save(any(UserAchievement.class));
+    }
+}

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
@@ -45,6 +45,7 @@ public class SimulationMatchServiceEventTest {
     @Mock private PlayerHistoryService playerHistoryService;
     @Mock private InjuryService injuryService;
     @Mock private RankingService rankingService;
+    @Mock private AchievementService achievementService;
 
     private Match match;
     private Player playerWithNullCondition;

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceHomeAdvantageTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceHomeAdvantageTest.java
@@ -46,6 +46,7 @@ public class SimulationMatchServiceHomeAdvantageTest {
     @Mock private PlayerRepository playerRepository;
     @Mock private PlayerHistoryService playerHistoryService;
     @Mock private InjuryService injuryService;
+    @Mock private AchievementService achievementService;
 
     @Test
     public void testHomeAdvantage_FullStadium() {

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceTest.java
@@ -53,6 +53,7 @@ public class SimulationMatchServiceTest {
     @Mock private PlayerRepository playerRepository;
     @Mock private PlayerHistoryService playerHistoryService;
     @Mock private InjuryService injuryService;
+    @Mock private AchievementService achievementService;
 
     @Test
     public void testSimulateMatch() {


### PR DESCRIPTION
Implemented the core logic for the Achievement system as defined in `gamification-tasks/3-achievements/2-achievement-logic.md`.

Changes:
1.  **ManagerProgressionService**: Created a service to handle manager XP, levels, and perks. This was a missing dependency required for achievements.
2.  **AchievementService**: Created the main service to check conditions and unlock achievements.
    *   `checkAndUnlock`: Generic method to unlock and award XP.
    *   `checkMatchAchievements`: Logic for `GOLEADOR` and `COMEBACK_KING`.
    *   `checkSeasonAchievements`: Logic for `WIN_LEAGUE` and `PROMOTION`.
    *   `checkFinancialAchievements`: Logic for `TYCOON`.
3.  **Integration**:
    *   `SimulationMatchService`: Added a call to `checkMatchAchievements` after match simulation.
    *   `SeasonService`: Added a call to `checkSeasonAchievements` when a season ends (before deactivating it).
    *   `FinancialService`: Added a call to `checkFinancialAchievements` during financial transactions and monthly processing.
4.  **Testing**:
    *   Created `AchievementServiceTest` with unit tests for all logic.
    *   Updated `SimulationMatchServiceTest`, `SimulationMatchServiceEventTest`, and `SimulationMatchServiceHomeAdvantageTest` to include the new `AchievementService` mock.

---
*PR created automatically by Jules for task [15828590116182412726](https://jules.google.com/task/15828590116182412726) started by @lollito*