### PR TITLE
Implement Quest Event Listeners

### DIFF
--- a/src/main/java/com/lollito/fm/event/MatchFinishedEvent.java
+++ b/src/main/java/com/lollito/fm/event/MatchFinishedEvent.java
@@ -1,0 +1,15 @@
+package com.lollito.fm.event;
+
+import org.springframework.context.ApplicationEvent;
+import com.lollito.fm.model.Match;
+import lombok.Getter;
+
+@Getter
+public class MatchFinishedEvent extends ApplicationEvent {
+    private final Match match;
+
+    public MatchFinishedEvent(Object source, Match match) {
+        super(source);
+        this.match = match;
+    }
+}

--- a/src/main/java/com/lollito/fm/event/ScoutingCompletedEvent.java
+++ b/src/main/java/com/lollito/fm/event/ScoutingCompletedEvent.java
@@ -1,0 +1,15 @@
+package com.lollito.fm.event;
+
+import org.springframework.context.ApplicationEvent;
+import com.lollito.fm.model.ScoutingAssignment;
+import lombok.Getter;
+
+@Getter
+public class ScoutingCompletedEvent extends ApplicationEvent {
+    private final ScoutingAssignment assignment;
+
+    public ScoutingCompletedEvent(Object source, ScoutingAssignment assignment) {
+        super(source);
+        this.assignment = assignment;
+    }
+}

--- a/src/main/java/com/lollito/fm/event/TrainingCompletedEvent.java
+++ b/src/main/java/com/lollito/fm/event/TrainingCompletedEvent.java
@@ -1,0 +1,15 @@
+package com.lollito.fm.event;
+
+import org.springframework.context.ApplicationEvent;
+import com.lollito.fm.model.TrainingSession;
+import lombok.Getter;
+
+@Getter
+public class TrainingCompletedEvent extends ApplicationEvent {
+    private final TrainingSession session;
+
+    public TrainingCompletedEvent(Object source, TrainingSession session) {
+        super(source);
+        this.session = session;
+    }
+}

--- a/src/main/java/com/lollito/fm/event/TransferCompletedEvent.java
+++ b/src/main/java/com/lollito/fm/event/TransferCompletedEvent.java
@@ -1,0 +1,23 @@
+package com.lollito.fm.event;
+
+import java.math.BigDecimal;
+import org.springframework.context.ApplicationEvent;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Player;
+import lombok.Getter;
+
+@Getter
+public class TransferCompletedEvent extends ApplicationEvent {
+    private final Player player;
+    private final Club buyerClub;
+    private final Club sellerClub;
+    private final BigDecimal amount;
+
+    public TransferCompletedEvent(Object source, Player player, Club buyerClub, Club sellerClub, BigDecimal amount) {
+        super(source);
+        this.player = player;
+        this.buyerClub = buyerClub;
+        this.sellerClub = sellerClub;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/lollito/fm/listener/QuestEventListener.java
+++ b/src/main/java/com/lollito/fm/listener/QuestEventListener.java
@@ -1,0 +1,99 @@
+package com.lollito.fm.listener;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.lollito.fm.event.MatchFinishedEvent;
+import com.lollito.fm.event.ScoutingCompletedEvent;
+import com.lollito.fm.event.TrainingCompletedEvent;
+import com.lollito.fm.event.TransferCompletedEvent;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.QuestType;
+import com.lollito.fm.model.User;
+import com.lollito.fm.service.QuestService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class QuestEventListener {
+
+    @Autowired
+    private QuestService questService;
+
+    @EventListener
+    public void onMatchFinished(MatchFinishedEvent event) {
+        Match match = event.getMatch();
+        log.debug("Processing match finished event for match {}", match.getId());
+
+        processMatchForUser(match.getHome().getUser(), match, true);
+        processMatchForUser(match.getAway().getUser(), match, false);
+    }
+
+    private void processMatchForUser(User user, Match match, boolean isHome) {
+        if (user == null) return;
+
+        // Play Match
+        questService.incrementProgress(user, QuestType.PLAY_MATCH, 1);
+
+        int homeScore = match.getHomeScore() != null ? match.getHomeScore() : 0;
+        int awayScore = match.getAwayScore() != null ? match.getAwayScore() : 0;
+        int userScore = isHome ? homeScore : awayScore;
+        int opponentScore = isHome ? awayScore : homeScore;
+
+        // Win Match
+        if (userScore > opponentScore) {
+            questService.incrementProgress(user, QuestType.WIN_MATCH, 1);
+        }
+
+        // Clean Sheet
+        if (opponentScore == 0) {
+            questService.incrementProgress(user, QuestType.CLEAN_SHEET, 1);
+        }
+
+        // Score Goals
+        if (userScore > 0) {
+            questService.incrementProgress(user, QuestType.SCORE_GOALS, userScore);
+        }
+    }
+
+    @EventListener
+    public void onTrainingCompleted(TrainingCompletedEvent event) {
+        if (event.getSession() == null || event.getSession().getTeam() == null
+                || event.getSession().getTeam().getClub() == null) {
+            return;
+        }
+
+        User user = event.getSession().getTeam().getClub().getUser();
+        if (user != null) {
+            log.debug("Processing training completed event for user {}", user.getId());
+            questService.incrementProgress(user, QuestType.TRAIN_SESSION, 1);
+        }
+    }
+
+    @EventListener
+    public void onScoutingCompleted(ScoutingCompletedEvent event) {
+        if (event.getAssignment() == null || event.getAssignment().getScout() == null
+                || event.getAssignment().getScout().getClub() == null) {
+            return;
+        }
+
+        User user = event.getAssignment().getScout().getClub().getUser();
+        if (user != null) {
+            log.debug("Processing scouting completed event for user {}", user.getId());
+            questService.incrementProgress(user, QuestType.SCOUT_PLAYER, 1);
+        }
+    }
+
+    @EventListener
+    public void onTransferCompleted(TransferCompletedEvent event) {
+        if (event.getBuyerClub() == null) return;
+
+        User user = event.getBuyerClub().getUser();
+        if (user != null) {
+            log.debug("Processing transfer completed event for user {}", user.getId());
+            questService.incrementProgress(user, QuestType.SIGN_PLAYER, 1);
+        }
+    }
+}

--- a/src/main/java/com/lollito/fm/service/MatchProcessor.java
+++ b/src/main/java/com/lollito/fm/service/MatchProcessor.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lollito.fm.event.MatchFinishedEvent;
 import com.lollito.fm.mapper.MatchMapper;
 import com.lollito.fm.mapper.MatchPlayerStatsMapper;
 import com.lollito.fm.model.EventHistory;
@@ -54,6 +56,7 @@ public class MatchProcessor {
     @Autowired private PlayerService playerService;
     @Autowired private PlayerHistoryService playerHistoryService;
     @Autowired private RankingService rankingService;
+    @Autowired private ApplicationEventPublisher eventPublisher;
 
     @Async
     @Transactional
@@ -176,6 +179,8 @@ public class MatchProcessor {
 
             rankingService.update(match);
             checkRoundAndSeasonProgression(match);
+
+            eventPublisher.publishEvent(new MatchFinishedEvent(this, match));
 
             // Notify users match ended
             notifyUser(match.getHome().getUser(), match.getId(), "MATCH_ENDED", "Match Ended!");

--- a/src/main/java/com/lollito/fm/service/ScoutingService.java
+++ b/src/main/java/com/lollito/fm/service/ScoutingService.java
@@ -8,12 +8,14 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.lollito.fm.event.ScoutingCompletedEvent;
 import com.lollito.fm.dto.AddToWatchlistRequest;
 import com.lollito.fm.dto.PlayerDTO;
 import com.lollito.fm.dto.ScoutingRecommendationDTO;
@@ -48,6 +50,7 @@ public class ScoutingService {
     @Autowired private PlayerService playerService;
     @Autowired private ClubService clubService;
     @Autowired private WatchlistService watchlistService;
+    @Autowired private ApplicationEventPublisher eventPublisher;
 
     public List<Scout> getClubScouts(Long clubId) {
         Club club = clubService.findById(clubId);
@@ -150,6 +153,8 @@ public class ScoutingService {
                                  assignment.getScout().getClub(), report);
 
         assignmentRepository.save(assignment);
+
+        eventPublisher.publishEvent(new ScoutingCompletedEvent(this, assignment));
     }
 
     public ScoutingReport generateScoutingReport(ScoutingAssignment assignment) {

--- a/src/main/java/com/lollito/fm/service/TrainingService.java
+++ b/src/main/java/com/lollito/fm/service/TrainingService.java
@@ -9,12 +9,14 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.lollito.fm.event.TrainingCompletedEvent;
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Player;
 import com.lollito.fm.model.PlayerTrainingResult;
@@ -65,6 +67,9 @@ public class TrainingService {
 
     @Autowired
     private ClubRepository clubRepository;
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
 
     /**
      * Process daily training for all teams
@@ -170,7 +175,11 @@ public class TrainingService {
         session.setEndDate(LocalDate.now());
 
         // Session save will cascade save the new results added to playerResults
-        return trainingSessionRepository.save(session);
+        session = trainingSessionRepository.save(session);
+
+        eventPublisher.publishEvent(new TrainingCompletedEvent(this, session));
+
+        return session;
     }
 
     /**

--- a/src/main/java/com/lollito/fm/service/TransferService.java
+++ b/src/main/java/com/lollito/fm/service/TransferService.java
@@ -6,9 +6,11 @@ import java.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.lollito.fm.event.TransferCompletedEvent;
 import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Player;
 import com.lollito.fm.model.TransactionCategory;
@@ -24,6 +26,7 @@ public class TransferService {
     @Autowired private FinancialService financialService;
     @Autowired private ClubService clubService;
     @Autowired private TeamService teamService;
+    @Autowired private ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void buyPlayer(Long playerId, Long buyerClubId) {
@@ -74,5 +77,7 @@ public class TransferService {
         player.setOnSale(false);
 
         playerService.save(player);
+
+        eventPublisher.publishEvent(new TransferCompletedEvent(this, player, buyerClub, sellerClub, price));
     }
 }

--- a/src/test/java/com/lollito/fm/listener/QuestEventListenerTest.java
+++ b/src/test/java/com/lollito/fm/listener/QuestEventListenerTest.java
@@ -1,0 +1,133 @@
+package com.lollito.fm.listener;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.event.MatchFinishedEvent;
+import com.lollito.fm.event.ScoutingCompletedEvent;
+import com.lollito.fm.event.TrainingCompletedEvent;
+import com.lollito.fm.event.TransferCompletedEvent;
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.Player;
+import com.lollito.fm.model.QuestType;
+import com.lollito.fm.model.Scout;
+import com.lollito.fm.model.ScoutingAssignment;
+import com.lollito.fm.model.Team;
+import com.lollito.fm.model.TrainingSession;
+import com.lollito.fm.model.User;
+import com.lollito.fm.service.QuestService;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestEventListenerTest {
+
+    @Mock
+    private QuestService questService;
+
+    @InjectMocks
+    private QuestEventListener questEventListener;
+
+    private User homeUser;
+    private User awayUser;
+    private Match match;
+
+    @BeforeEach
+    void setUp() {
+        homeUser = new User();
+        homeUser.setId(1L);
+
+        awayUser = new User();
+        awayUser.setId(2L);
+
+        Club homeClub = new Club();
+        homeClub.setUser(homeUser);
+
+        Club awayClub = new Club();
+        awayClub.setUser(awayUser);
+
+        Team homeTeam = new Team();
+        homeTeam.setClub(homeClub);
+
+        Team awayTeam = new Team();
+        awayTeam.setClub(awayClub);
+        homeClub.setTeam(homeTeam);
+        awayClub.setTeam(awayTeam);
+
+        match = new Match();
+        match.setId(100L);
+        match.setHome(homeClub);
+        match.setAway(awayClub);
+    }
+
+    @Test
+    void onMatchFinished_HomeWin() {
+        match.setHomeScore(2);
+        match.setAwayScore(0);
+
+        MatchFinishedEvent event = new MatchFinishedEvent(this, match);
+        questEventListener.onMatchFinished(event);
+
+        // Home User: Play, Win, Clean Sheet, Score Goals
+        verify(questService).incrementProgress(homeUser, QuestType.PLAY_MATCH, 1);
+        verify(questService).incrementProgress(homeUser, QuestType.WIN_MATCH, 1);
+        verify(questService).incrementProgress(homeUser, QuestType.CLEAN_SHEET, 1);
+        verify(questService).incrementProgress(homeUser, QuestType.SCORE_GOALS, 2);
+
+        // Away User: Play
+        verify(questService).incrementProgress(awayUser, QuestType.PLAY_MATCH, 1);
+        verify(questService, never()).incrementProgress(awayUser, QuestType.WIN_MATCH, 1);
+        verify(questService, never()).incrementProgress(awayUser, QuestType.CLEAN_SHEET, 1);
+        verify(questService, never()).incrementProgress(eq(awayUser), eq(QuestType.SCORE_GOALS), anyInt());
+    }
+
+    @Test
+    void onTrainingCompleted() {
+        TrainingSession session = new TrainingSession();
+        Team team = match.getHome().getTeam();
+        session.setTeam(team);
+
+        TrainingCompletedEvent event = new TrainingCompletedEvent(this, session);
+        questEventListener.onTrainingCompleted(event);
+
+        verify(questService).incrementProgress(homeUser, QuestType.TRAIN_SESSION, 1);
+    }
+
+    @Test
+    void onScoutingCompleted() {
+        Scout scout = new Scout();
+        Club club = match.getHome();
+        scout.setClub(club);
+
+        ScoutingAssignment assignment = new ScoutingAssignment();
+        assignment.setScout(scout);
+
+        ScoutingCompletedEvent event = new ScoutingCompletedEvent(this, assignment);
+        questEventListener.onScoutingCompleted(event);
+
+        verify(questService).incrementProgress(homeUser, QuestType.SCOUT_PLAYER, 1);
+    }
+
+    @Test
+    void onTransferCompleted() {
+        Player player = new Player();
+        Club buyerClub = match.getHome();
+        Club sellerClub = match.getAway();
+        BigDecimal amount = BigDecimal.valueOf(1000000);
+
+        TransferCompletedEvent event = new TransferCompletedEvent(this, player, buyerClub, sellerClub, amount);
+        questEventListener.onTransferCompleted(event);
+
+        verify(questService).incrementProgress(homeUser, QuestType.SIGN_PLAYER, 1);
+    }
+}


### PR DESCRIPTION
Implemented the quest listener system as defined in `gamification-tasks/2-quests-system/3-quest-listeners.md`.
This includes creating event classes for key game actions (match finish, training completion, scouting completion, transfer completion) and a `QuestEventListener` that subscribes to these events to update user quest progress via `QuestService`.
Services were updated to publish these events using `ApplicationEventPublisher`.
Unit tests were added to verify the listener logic.

---
*PR created automatically by Jules for task [6213631167352423445](https://jules.google.com/task/6213631167352423445) started by @lollito*