### PR TITLE
Implement Manager Perks logic in core services

### DIFF
--- a/src/main/java/com/lollito/fm/service/ScoutingService.java
+++ b/src/main/java/com/lollito/fm/service/ScoutingService.java
@@ -22,6 +22,7 @@ import com.lollito.fm.model.Club;
 import com.lollito.fm.model.Player;
 import com.lollito.fm.model.PlayerScoutingStatus;
 import com.lollito.fm.model.RecommendationLevel;
+import com.lollito.fm.model.ManagerPerk;
 import com.lollito.fm.model.Scout;
 import com.lollito.fm.model.ScoutSpecialization;
 import com.lollito.fm.model.ScoutStatus;
@@ -48,6 +49,7 @@ public class ScoutingService {
     @Autowired private PlayerService playerService;
     @Autowired private ClubService clubService;
     @Autowired private WatchlistService watchlistService;
+    @Autowired private ManagerProgressionService managerProgressionService;
 
     public List<Scout> getClubScouts(Long clubId) {
         Club club = clubService.findById(clubId);
@@ -86,6 +88,12 @@ public class ScoutingService {
         }
 
         int daysToComplete = calculateScoutingDuration(scout, player, ScoutingType.PLAYER);
+
+        if (scout.getClub() != null && scout.getClub().getUser() != null) {
+            if (managerProgressionService.hasPerk(scout.getClub().getUser(), ManagerPerk.HAWK_EYE)) {
+                daysToComplete = (int) (daysToComplete * 0.9);
+            }
+        }
 
         ScoutingAssignment assignment = ScoutingAssignment.builder()
             .scout(scout)

--- a/src/main/java/com/lollito/fm/service/TrainingService.java
+++ b/src/main/java/com/lollito/fm/service/TrainingService.java
@@ -25,6 +25,7 @@ import com.lollito.fm.model.TrainingPerformance;
 import com.lollito.fm.model.TrainingPlan;
 import com.lollito.fm.model.TrainingSession;
 import com.lollito.fm.model.TrainingStatus;
+import com.lollito.fm.model.ManagerPerk;
 import com.lollito.fm.dto.StaffBonusesDTO;
 import com.lollito.fm.model.dto.IndividualFocusDTO;
 import com.lollito.fm.model.dto.IndividualFocusRequest;
@@ -65,6 +66,9 @@ public class TrainingService {
 
     @Autowired
     private ClubRepository clubRepository;
+
+    @Autowired
+    private ManagerProgressionService managerProgressionService;
 
     /**
      * Process daily training for all teams
@@ -323,6 +327,14 @@ public class TrainingService {
      */
     private void applySkillImprovement(Player player, TrainingFocus focus,
                                      double improvement) {
+        if (focus == TrainingFocus.TECHNICAL || focus == TrainingFocus.BALANCED) {
+            if (player.getTeam() != null && player.getTeam().getClub() != null && player.getTeam().getClub().getUser() != null) {
+                if (managerProgressionService.hasPerk(player.getTeam().getClub().getUser(), ManagerPerk.VIDEO_ANALYST)) {
+                    improvement *= 1.05;
+                }
+            }
+        }
+
         List<String> affectedSkills = focus.getAffectedSkills();
         double improvementPerSkill = improvement / affectedSkills.size();
 

--- a/src/main/java/com/lollito/fm/service/YouthAcademyService.java
+++ b/src/main/java/com/lollito/fm/service/YouthAcademyService.java
@@ -16,6 +16,7 @@ import com.lollito.fm.model.Contract;
 import com.lollito.fm.model.ContractStatus;
 import com.lollito.fm.model.Foot;
 import com.lollito.fm.model.Player;
+import com.lollito.fm.model.ManagerPerk;
 import com.lollito.fm.model.PlayerRole;
 import com.lollito.fm.model.Team;
 import com.lollito.fm.model.YouthAcademy;
@@ -37,6 +38,7 @@ public class YouthAcademyService {
     @Autowired private PlayerService playerService;
     @Autowired private ContractRepository contractRepository;
     @Autowired private ClubService clubService;
+    @Autowired private ManagerProgressionService managerProgressionService;
 
     @Value("${fm.youth.generation.count:3}")
     private Integer generationCount;
@@ -79,6 +81,12 @@ public class YouthAcademyService {
 
         double base = 20.0 + ((academy.getOverallQuality() != null ? academy.getOverallQuality() : 1) * 3.0);
         base *= qualityMultiplier;
+
+        if (academy.getClub() != null && academy.getClub().getUser() != null) {
+            if (managerProgressionService.hasPerk(academy.getClub().getUser(), ManagerPerk.GLOBAL_NETWORK)) {
+                base += 5.0;
+            }
+        }
 
         YouthCandidate candidate = YouthCandidate.builder()
             .name(name)


### PR DESCRIPTION
Implemented various Manager Perks by modifying existing services to check for unlocked perks via `ManagerProgressionService`.
- `ScoutingService`: Reduced scouting duration by 10% with `HAWK_EYE`.
- `YouthAcademyService`: Increased base quality of generated youth candidates with `GLOBAL_NETWORK`.
- `TrainingService`: Increased skill improvement by 5% for TECHNICAL/BALANCED focus with `VIDEO_ANALYST`.
- `SimulationMatchService`: Added +2 to home advantage with `FORTRESS`. Implemented morale updates and reduced morale loss on defeat with `MOTIVATOR`.
- `FinancialService`: Increased sponsorship payments by 5% with `MARKETING_GURU`. Added weekly interest on positive balance with `INVESTOR`.
- `ContractService`: Reduced player wage demands by 5% with `NEGOTIATOR`.

---
*PR created automatically by Jules for task [5277317747085317862](https://jules.google.com/task/5277317747085317862) started by @lollito*