### PR TITLE
Implement Quest Widget and Backend Integration

### DIFF
--- a/fm-admin/src/components/Quest/QuestList.js
+++ b/fm-admin/src/components/Quest/QuestList.js
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { getQuests, claimQuest } from '../../services/api';
+
+const QuestList = ({ limit }) => {
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [claiming, setClaiming] = useState(null);
+
+  const fetchQuests = async () => {
+    try {
+      const response = await getQuests();
+      setQuests(response.data);
+    } catch (err) {
+      setError('Failed to load quests');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchQuests();
+  }, []);
+
+  const handleClaim = async (id) => {
+    setClaiming(id);
+    try {
+      await claimQuest(id);
+      await fetchQuests();
+    } catch (err) {
+      console.error('Failed to claim reward', err);
+    } finally {
+      setClaiming(null);
+    }
+  };
+
+  if (loading) return <div>Loading quests...</div>;
+  if (error) return <div>{error}</div>;
+
+  const activeQuests = quests.filter(q => q.status === 'ACTIVE' || q.status === 'COMPLETED');
+
+  // Sort: COMPLETED first
+  activeQuests.sort((a, b) => {
+      if (a.status === 'COMPLETED' && b.status !== 'COMPLETED') return -1;
+      if (a.status !== 'COMPLETED' && b.status === 'COMPLETED') return 1;
+      return 0;
+  });
+
+  const dailyQuests = activeQuests.filter(q => q.frequency === 'DAILY');
+  const weeklyQuests = activeQuests.filter(q => q.frequency === 'WEEKLY');
+
+  const renderQuest = (quest) => {
+    const isCompleted = quest.status === 'COMPLETED';
+    const progress = Math.min((quest.currentValue / quest.targetValue) * 100, 100);
+
+    return (
+      <div key={quest.id} className="card mb-3" style={{ borderLeft: isCompleted ? '4px solid var(--success)' : '4px solid var(--primary)' }}>
+        <div className="card-body p-3">
+          <div className="d-flex justify-content-between align-items-center mb-2">
+            <h5 className="mb-0" style={{ fontSize: '1rem' }}>{quest.description}</h5>
+            {isCompleted && (
+              <button
+                className="btn btn-sm"
+                style={{ backgroundColor: 'var(--success)', borderColor: 'var(--success)', color: '#fff' }}
+                onClick={() => handleClaim(quest.id)}
+                disabled={claiming === quest.id}
+              >
+                {claiming === quest.id ? 'Claiming...' : 'Claim Reward'}
+              </button>
+            )}
+          </div>
+          <div className="d-flex justify-content-between text-muted small mb-1">
+            <span>{quest.currentValue} / {quest.targetValue}</span>
+            <span>{quest.rewardXp} XP</span>
+          </div>
+          <div style={{ height: '6px', backgroundColor: 'var(--bg-darker)', borderRadius: '3px', overflow: 'hidden' }}>
+            <div
+              style={{
+                  width: `${progress}%`,
+                  height: '100%',
+                  backgroundColor: isCompleted ? 'var(--success)' : 'var(--primary)',
+                  transition: 'width 0.3s'
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="quest-list">
+        {activeQuests.length === 0 && <p className="text-muted">No active quests.</p>}
+
+        {dailyQuests.length > 0 && (
+            <div className="mb-4">
+                <h6 className="text-uppercase text-muted mb-3" style={{ fontSize: '0.75rem', letterSpacing: '1px' }}>Daily Quests</h6>
+                {dailyQuests.slice(0, limit || dailyQuests.length).map(renderQuest)}
+            </div>
+        )}
+
+        {weeklyQuests.length > 0 && (
+            <div>
+                <h6 className="text-uppercase text-muted mb-3" style={{ fontSize: '0.75rem', letterSpacing: '1px' }}>Weekly Quests</h6>
+                {weeklyQuests.slice(0, limit || weeklyQuests.length).map(renderQuest)}
+            </div>
+        )}
+    </div>
+  );
+};
+
+export default QuestList;

--- a/fm-admin/src/components/Quest/QuestList.test.js
+++ b/fm-admin/src/components/Quest/QuestList.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuestList from './QuestList';
+import * as api from '../../services/api';
+
+// Mock the API module
+jest.mock('../../services/api');
+
+const mockQuests = [
+  {
+    id: 1,
+    description: 'Win a match',
+    currentValue: 0,
+    targetValue: 1,
+    status: 'ACTIVE',
+    frequency: 'DAILY',
+    rewardXp: 100,
+    rewardMoney: 10000
+  },
+  {
+    id: 2,
+    description: 'Score 5 goals',
+    currentValue: 5,
+    targetValue: 5,
+    status: 'COMPLETED',
+    frequency: 'WEEKLY',
+    rewardXp: 500,
+    rewardMoney: 50000
+  }
+];
+
+describe('QuestList Component', () => {
+  beforeEach(() => {
+    api.getQuests.mockResolvedValue({ data: mockQuests });
+    api.claimQuest.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders quests grouped by frequency', async () => {
+    render(<QuestList />);
+
+    expect(screen.getByText('Loading quests...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading quests...')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Daily Quests')).toBeInTheDocument();
+    expect(screen.getByText('Weekly Quests')).toBeInTheDocument();
+    expect(screen.getByText('Win a match')).toBeInTheDocument();
+    expect(screen.getByText('Score 5 goals')).toBeInTheDocument();
+  });
+
+  test('handles claim reward', async () => {
+    render(<QuestList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Claim Reward')).toBeInTheDocument();
+    });
+
+    const claimButton = screen.getByText('Claim Reward');
+    fireEvent.click(claimButton);
+
+    expect(screen.getByText('Claiming...')).toBeInTheDocument();
+
+    await waitFor(() => {
+        expect(api.claimQuest).toHaveBeenCalledWith(2);
+    });
+
+    // It refetches quests after claim
+    await waitFor(() => {
+        expect(api.getQuests).toHaveBeenCalledTimes(2); // Initial + after claim
+    });
+  });
+
+  test('displays progress correctly', async () => {
+      render(<QuestList />);
+      await waitFor(() => {
+          expect(screen.getByText('0 / 1')).toBeInTheDocument();
+          expect(screen.getByText('5 / 5')).toBeInTheDocument();
+      });
+  });
+});

--- a/fm-admin/src/pages/Dashboard.js
+++ b/fm-admin/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import api from '../services/api';
 import Layout from '../components/Layout';
+import QuestList from '../components/Quest/QuestList';
 
 const Dashboard = () => {
   const [stats, setStats] = useState({
@@ -40,11 +41,22 @@ const Dashboard = () => {
   return (
     <Layout>
       <h1 style={{ color: 'var(--text)', marginBottom: '32px' }}>Dashboard</h1>
-      <div className="row">
+      <div className="row mb-4">
         <Card title="Users" value={stats.users} />
         <Card title="Clubs" value={stats.clubs} />
         <Card title="Matches" value={stats.matches} />
         <Card title="Leagues" value={stats.leagues} />
+      </div>
+
+      <div className="row">
+        <div className="col">
+          <div className="card">
+            <div className="card-header">Active Quests</div>
+            <div className="card-body">
+              <QuestList limit={3} />
+            </div>
+          </div>
+        </div>
       </div>
     </Layout>
   );

--- a/fm-admin/src/services/api.js
+++ b/fm-admin/src/services/api.js
@@ -42,4 +42,7 @@ export const getAllLiveMatches = () => api.get('/live-match/all');
 export const forceFinishMatch = (id) => api.post('/live-match/' + id + '/finish');
 export const resetMatch = (id) => api.post('/live-match/' + id + '/reset');
 
+export const getQuests = (status) => api.get('/quests', { params: { status } });
+export const claimQuest = (id) => api.post('/quests/' + id + '/claim');
+
 export default api;

--- a/src/main/java/com/lollito/fm/controller/QuestController.java
+++ b/src/main/java/com/lollito/fm/controller/QuestController.java
@@ -1,0 +1,57 @@
+package com.lollito.fm.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lollito.fm.model.Quest;
+import com.lollito.fm.model.QuestStatus;
+import com.lollito.fm.model.User;
+import com.lollito.fm.repository.QuestRepository;
+import com.lollito.fm.service.QuestService;
+import com.lollito.fm.service.UserService;
+
+@RestController
+@RequestMapping("/api/quests")
+public class QuestController {
+
+    @Autowired
+    private QuestRepository questRepository;
+
+    @Autowired
+    private QuestService questService;
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    public ResponseEntity<List<Quest>> getQuests(
+            @RequestParam(required = false) QuestStatus status,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication.getName());
+        List<Quest> quests;
+
+        if (status != null) {
+            quests = questRepository.findByUserIdAndStatus(user.getId(), status);
+        } else {
+            quests = questRepository.findByUserId(user.getId());
+        }
+
+        return ResponseEntity.ok(quests);
+    }
+
+    @PostMapping("/{id}/claim")
+    public ResponseEntity<Void> claimQuest(@PathVariable Long id) {
+        questService.claimReward(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/lollito/fm/repository/QuestRepository.java
+++ b/src/main/java/com/lollito/fm/repository/QuestRepository.java
@@ -14,5 +14,7 @@ import com.lollito.fm.model.QuestStatus;
 public interface QuestRepository extends JpaRepository<Quest, Long> {
     List<Quest> findByUserIdAndStatusAndExpirationDateAfter(Long userId, QuestStatus status, LocalDateTime now);
     List<Quest> findByUserIdAndFrequency(Long userId, QuestFrequency frequency);
+    List<Quest> findByUserIdAndStatus(Long userId, QuestStatus status);
+    List<Quest> findByUserId(Long userId);
     void deleteByExpirationDateBefore(LocalDateTime now);
 }


### PR DESCRIPTION
Implemented the Quest Widget for the Manager Dashboard in `fm-admin`.
This includes:
1.  Backend:
    -   `QuestRepository`: Added methods to find quests by user and status.
    -   `QuestController`: New controller to handle quest retrieval and claiming rewards.
2.  Frontend (`fm-admin`):
    -   `api.js`: Added API calls for quests.
    -   `QuestList.js`: A new component that displays Daily and Weekly quests, tracks progress, and allows claiming rewards. Grouped by frequency and sorted by completion status.
    -   `Dashboard.js`: Embedded the `QuestList` widget.
    -   `QuestList.test.js`: Unit tests for the new component.

---
*PR created automatically by Jules for task [184685243473146845](https://jules.google.com/task/184685243473146845) started by @lollito*