### PR TITLE
Limit homepage news to 3 most recent items

### DIFF
--- a/fm-web/src/pages/Home.js
+++ b/fm-web/src/pages/Home.js
@@ -22,7 +22,7 @@ const Home = () => {
     const fetchData = async () => {
       try {
         const [newsRes, nextRes, prevRes, rankRes] = await Promise.all([
-          api.get('/news/'),
+          api.get('/news/', { params: { limit: 3 } }),
           api.get('/match/next'),
           api.get('/match/previous'),
           api.get('/ranking/')

--- a/src/main/java/com/lollito/fm/controller/rest/NewsController.java
+++ b/src/main/java/com/lollito/fm/controller/rest/NewsController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lollito.fm.mapper.NewsMapper;
@@ -30,7 +31,12 @@ public class NewsController {
     }
 	
 	@RequestMapping(value = "/", method = RequestMethod.GET)
-    public List<NewsDTO> findAll(Model model) {
+    public List<NewsDTO> findAll(@RequestParam(required = false) Integer limit, Model model) {
+        if (limit != null && limit > 0) {
+            return newsService.findLatest(limit).stream()
+                .map(newsMapper::toDto)
+                .collect(Collectors.toList());
+        }
         return newsService.findAll().stream()
 			.map(newsMapper::toDto)
 			.collect(Collectors.toList());

--- a/src/main/java/com/lollito/fm/service/NewsService.java
+++ b/src/main/java/com/lollito/fm/service/NewsService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.lollito.fm.model.News;
@@ -29,4 +31,8 @@ public class NewsService {
 		return newsRepository.findAll();
 	}
 	
+	public List<News> findLatest(int limit) {
+		return newsRepository.findAll(PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "date"))).getContent();
+	}
+
 }

--- a/src/test/java/com/lollito/fm/service/NewsServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/NewsServiceTest.java
@@ -1,0 +1,49 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.lollito.fm.model.News;
+import com.lollito.fm.repository.rest.NewsRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class NewsServiceTest {
+
+    @Mock
+    private NewsRepository newsRepository;
+
+    @InjectMocks
+    private NewsService newsService;
+
+    @Test
+    public void testFindLatest() {
+        int limit = 3;
+        News news1 = new News("News 1", LocalDateTime.now());
+        News news2 = new News("News 2", LocalDateTime.now().minusDays(1));
+        News news3 = new News("News 3", LocalDateTime.now().minusDays(2));
+        List<News> expectedNews = Arrays.asList(news1, news2, news3);
+        Page<News> page = new PageImpl<>(expectedNews);
+
+        when(newsRepository.findAll(any(Pageable.class))).thenReturn(page);
+
+        List<News> result = newsService.findLatest(limit);
+
+        assertEquals(3, result.size());
+        verify(newsRepository).findAll(any(Pageable.class));
+    }
+}


### PR DESCRIPTION
This PR updates the fm-web homepage to display only the 3 most recent news items, as requested. It implements a backend change to support a `limit` query parameter in the `/api/news` endpoint, ensuring efficient data retrieval and correct sorting by date. A new unit test `NewsServiceTest` is added to verify the backend logic. The frontend `Home.js` is updated to use this new parameter.

---
*PR created automatically by Jules for task [14527367288940135436](https://jules.google.com/task/14527367288940135436) started by @lollito*