### PR TITLE
⚡ Bolt: Optimize career stats update with incremental logic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-10 - Incremental Updates for Player Career Stats
+**Learning:** Avoiding full recalculations of aggregated data (like career stats) by using incremental updates saved significant database I/O in the hot path of match simulation.
+**Action:** Look for other places where aggregated data is recalculated from scratch instead of incrementally updated.


### PR DESCRIPTION
Implemented an incremental update strategy for `PlayerCareerStats` within `PlayerHistoryService`. Previously, `updateCareerStats` would fetch all historical `PlayerSeasonStats` for a player to recalculate totals (goals, assists, matches, etc.) from scratch after every match. This was an O(N) operation (where N is the number of seasons played) executed for every player in every match.

The new `updateCareerStatsIncremental` method updates the existing `PlayerCareerStats` entity by adding the delta from the current match (`MatchPlayerStats`). This is an O(1) operation that avoids fetching the list of all past season stats, significantly reducing database I/O and processing time during match simulations.

Verified with `PlayerHistoryServiceTest` which confirms that `playerSeasonStatsRepository.findByPlayer` is no longer called during match updates, and that career totals are correctly incremented.

---
*PR created automatically by Jules for task [9676023555826647471](https://jules.google.com/task/9676023555826647471) started by @lollito*