### PR TITLE
feat(ui): improve navbar accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-19 - Missing Utility Classes
 **Learning:** Projects ported from frameworks like Bootstrap might leave behind class names (e.g., `spinner-border`) without the underlying CSS, leading to broken UI elements that are hard to spot visually (invisible spinners).
 **Action:** When auditing UI, check if "standard" utility classes are actually defined. Re-implementing them in the global theme can fix widespread issues instantly.
+
+## 2025-02-19 - Accessible Navigation Patterns
+**Learning:** Icon-only buttons (like hamburger menus or notifications) are common but often completely inaccessible to screen readers if they lack `aria-label`. Interactive elements like user dropdowns implemented with `div`s break keyboard navigation (Tab/Enter) unless explicitly given `role="button"`, `tabIndex="0"`, and key handlers.
+**Action:** Always add `aria-label` to icon buttons. For custom interactive components, ensure they are keyboard accessible or replace them with native `<button>` elements where possible to get accessibility for free.

--- a/fm-web/src/components/Navbar.js
+++ b/fm-web/src/components/Navbar.js
@@ -136,7 +136,7 @@ const Navbar = ({ onToggleMenu }) => {
     <nav className="navbar">
       {/* Left Section: Toggle & Title (Optional) */}
       <div className="navbar-left">
-        <button className="btn btn-primary" onClick={onToggleMenu}>
+        <button className="btn btn-primary" onClick={onToggleMenu} aria-label="Toggle menu">
           <i className="fas fa-bars"></i>
         </button>
       </div>
@@ -144,7 +144,7 @@ const Navbar = ({ onToggleMenu }) => {
       {/* Center Section: Search */}
       <div className="navbar-search">
         <i className="fas fa-search"></i>
-        <input type="text" placeholder="Search players, clubs, matches..." />
+        <input type="text" placeholder="Search players, clubs, matches..." aria-label="Search players, clubs, matches..." />
       </div>
 
       {/* Right Section: Status & User */}
@@ -153,7 +153,14 @@ const Navbar = ({ onToggleMenu }) => {
         {/* Level Indicator */}
         <div className="status-item level-display">
           <div className="level-text">Level {managerProfile?.level || user?.level || 1}</div>
-          <div className="progress-container">
+          <div
+            className="progress-container"
+            role="progressbar"
+            aria-valuenow={calculateLevelProgress()}
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Level Progress"
+          >
             <div
               className="progress-bar-fill"
               style={{ width: `${calculateLevelProgress()}%` }}
@@ -169,7 +176,7 @@ const Navbar = ({ onToggleMenu }) => {
 
         {/* Notifications */}
         <div className="notification-dropdown-container" ref={notificationRef}>
-            <button className="icon-btn" onClick={() => setShowNotificationDropdown(!showNotificationDropdown)}>
+            <button className="icon-btn" onClick={() => setShowNotificationDropdown(!showNotificationDropdown)} aria-label="Notifications">
             <i className="fas fa-bell"></i>
             {unreadNotifications.length > 0 && <span className="badge">{unreadNotifications.length}</span>}
             </button>
@@ -208,7 +215,17 @@ const Navbar = ({ onToggleMenu }) => {
         <div className="user-dropdown" ref={dropdownRef}>
           <div
             className="user-info"
+            role="button"
+            tabIndex="0"
+            aria-haspopup="true"
+            aria-expanded={showDropdown}
             onClick={() => setShowDropdown(!showDropdown)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setShowDropdown(!showDropdown);
+              }
+            }}
           >
             <div className="avatar">
               {getInitials(user?.username)}

--- a/fm-web/src/components/Navbar.test.js
+++ b/fm-web/src/components/Navbar.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import Navbar from './Navbar';
+import { AuthContext } from '../context/AuthContext';
+import { BrowserRouter } from 'react-router-dom';
+import * as api from '../services/api';
+import { Client } from '@stomp/stompjs';
+import '@testing-library/jest-dom';
+
+// Mock dependencies
+jest.mock('../services/api');
+jest.mock('sockjs-client', () => {
+    return jest.fn().mockImplementation(() => ({}));
+});
+jest.mock('@stomp/stompjs');
+
+const mockUser = {
+  username: 'TestManager',
+  level: 5,
+  club: {
+    finance: {
+      balance: 1500000
+    }
+  }
+};
+
+const mockLogout = jest.fn();
+
+describe('Navbar Accessibility', () => {
+  beforeEach(() => {
+    // Setup API mocks
+    api.getUnreadNotifications.mockResolvedValue({ data: [] });
+    api.getManagerProfile.mockResolvedValue({ data: { level: 5, currentXp: 500, xpForNextLevel: 1000 } });
+
+    // Setup Stomp mock
+    Client.mockImplementation(() => ({
+      activate: jest.fn(),
+      deactivate: jest.fn(),
+      subscribe: jest.fn()
+    }));
+  });
+
+  const renderNavbar = async () => {
+    await act(async () => {
+      render(
+        <AuthContext.Provider value={{ user: mockUser, logout: mockLogout }}>
+          <BrowserRouter>
+            <Navbar onToggleMenu={jest.fn()} />
+          </BrowserRouter>
+        </AuthContext.Provider>
+      );
+    });
+  };
+
+  test('Menu button has aria-label', async () => {
+    await renderNavbar();
+    const menuButton = screen.getByRole('button', { name: /toggle menu/i });
+    expect(menuButton).toBeInTheDocument();
+  });
+
+  test('Search input has aria-label', async () => {
+    await renderNavbar();
+    const searchInput = screen.getByRole('textbox', { name: /search/i });
+    expect(searchInput).toBeInTheDocument();
+  });
+
+  test('Notification button has aria-label', async () => {
+    await renderNavbar();
+    const notificationButton = screen.getByRole('button', { name: /notifications/i });
+    expect(notificationButton).toBeInTheDocument();
+  });
+
+  test('Level progress bar has role and aria attributes', async () => {
+    await renderNavbar();
+    const progressbar = await screen.findByRole('progressbar');
+    expect(progressbar).toBeInTheDocument();
+    expect(progressbar).toHaveAttribute('aria-label', 'Level Progress');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '50'); // 500 / 1000 * 100
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  test('User profile trigger is keyboard accessible', async () => {
+    await renderNavbar();
+    const userTrigger = screen.getByText('TestManager').closest('.user-info');
+    expect(userTrigger).toHaveAttribute('role', 'button');
+    expect(userTrigger).toHaveAttribute('tabIndex', '0');
+    expect(userTrigger).toHaveAttribute('aria-haspopup', 'true');
+
+    // Test keyboard interaction
+    await act(async () => {
+        fireEvent.keyDown(userTrigger, { key: 'Enter', code: 'Enter' });
+    });
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
🎨 Palette: Improved Navbar Accessibility

💡 **What:**
- Added `aria-label` to the hamburger menu, search input, and notification bell.
- Added proper ARIA roles and attributes to the level progress bar.
- Made the user profile dropdown keyboard-accessible by adding `role="button"`, `tabIndex="0"`, and `Enter`/`Space` key handlers.
- Added a new test file `fm-web/src/components/Navbar.test.js` to verify these improvements.

🎯 **Why:**
- Screen reader users could not identify the purpose of icon-only buttons.
- Keyboard users could not access or operate the user profile dropdown.
- The progress bar was not announced as such to assistive technologies.

♿ **Accessibility:**
- **Keyboard Navigation:** User dropdown is now focusable and actionable via keyboard.
- **Screen Readers:** All interactive elements now have accessible names and roles.


---
*PR created automatically by Jules for task [14264008032122265026](https://jules.google.com/task/14264008032122265026) started by @lollito*