### PR TITLE
⚡ Bolt: Batch player stats updates

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/PlayerCareerStatsRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/PlayerCareerStatsRepository.java
@@ -1,11 +1,15 @@
 package com.lollito.fm.repository.rest;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.lollito.fm.model.Player;
 import com.lollito.fm.model.PlayerCareerStats;
 
 @Repository
 public interface PlayerCareerStatsRepository extends JpaRepository<PlayerCareerStats, Long> {
 
+    List<PlayerCareerStats> findByPlayerIn(List<Player> players);
 }

--- a/src/main/java/com/lollito/fm/service/SimulationMatchService.java
+++ b/src/main/java/com/lollito/fm/service/SimulationMatchService.java
@@ -54,17 +54,22 @@ public class SimulationMatchService {
 	
 	public void simulate(List<Match> matches){
 		List<Player> allPlayersToSave = new ArrayList<>();
+		List<MatchPlayerStats> allMatchStats = new ArrayList<>();
 		matches.forEach(match -> {
 			simulateMatchLogic(match, null);
 			// Collect players
 			allPlayersToSave.addAll(match.getHome().getTeam().getPlayers());
 			allPlayersToSave.addAll(match.getAway().getTeam().getPlayers());
 
-			// Update player history stats
-			match.getPlayerStats().forEach(stats -> playerHistoryService.updateMatchStatistics(stats.getPlayer(), stats));
+			// Collect match stats for batch update
+			allMatchStats.addAll(match.getPlayerStats());
 		});
 
 		playerService.saveAll(allPlayersToSave);
+
+		// Batch update player history stats
+		playerHistoryService.updateMatchStatisticsBatch(allMatchStats);
+
 		matchRepository.saveAll(matches);
 		rankingService.updateAll(matches);
 


### PR DESCRIPTION
💡 What: Replaced the iterative `updateMatchStatistics` call inside the simulation loop with a new `updateMatchStatisticsBatch` method in `PlayerHistoryService`. This method fetches all necessary `PlayerSeasonStats` and `PlayerCareerStats` in single queries using `findBySeasonAndPlayerIn` and `findByPlayerIn` respectively, updates them in memory, and persists them using `saveAll`.

🎯 Why: The previous implementation suffered from a significant N+1 query problem. For every match simulated, it would iterate through ~22-30 players, and for each player, it would perform multiple SELECTs (for season and career stats) and multiple UPDATEs/INSERTs. In a simulation of 10 matches, this could result in ~600+ database calls.

📊 Impact: Drastically reduces the number of database queries during match simulation.
- Reads: Reduced from ~2*N queries (where N is total players in all matches) to 2 queries per batch (one for season stats, one for career stats).
- Writes: Reduced from ~2*N individual saves to 2 batch saves (`saveAll`).

🔬 Measurement: Verified with `SimulationMatchServiceTest` including a new `testSimulateMatchesBatch` test case. The logic ensures correct accumulation of stats even if a player plays multiple matches in a batch (though rare in standard flow). Existing functionality (single match simulation) is preserved.

---
*PR created automatically by Jules for task [3249803894462711460](https://jules.google.com/task/3249803894462711460) started by @lollito*