### PR TITLE
🎨 Palette: Improve notification dropdown accessibility

### DIFF
--- a/fm-web/src/components/Navbar.js
+++ b/fm-web/src/components/Navbar.js
@@ -189,15 +189,30 @@ const Navbar = ({ onToggleMenu }) => {
                             <div className="dropdown-item text-muted">No new notifications</div>
                         ) : (
                             unreadNotifications.map(notif => (
-                                <div key={notif.id} className="dropdown-item notification-item" onClick={() => {
-                                    if (notif.actionUrl) navigate(notif.actionUrl);
-                                }}>
-                                    <div className="notif-content">
+                <div key={notif.id} className="dropdown-item notification-item">
+                    <div
+                        className="notif-content"
+                        role={notif.actionUrl ? "button" : undefined}
+                        tabIndex={notif.actionUrl ? 0 : undefined}
+                        onClick={() => notif.actionUrl && navigate(notif.actionUrl)}
+                        onKeyDown={(e) => {
+                            if (notif.actionUrl && (e.key === 'Enter' || e.key === ' ')) {
+                                e.preventDefault();
+                                navigate(notif.actionUrl);
+                            }
+                        }}
+                        style={{ cursor: notif.actionUrl ? 'pointer' : 'default' }}
+                    >
                                         <div className="notif-title">{notif.title}</div>
                                         <div className="notif-message">{notif.message}</div>
                                         <small className="text-muted">{new Date(notif.createdAt).toLocaleTimeString()}</small>
                                     </div>
-                                    <button className="btn btn-sm btn-link text-muted" onClick={(e) => handleMarkRead(notif.id, e)}>
+                    <button
+                        className="btn btn-sm btn-link text-muted"
+                        onClick={(e) => handleMarkRead(notif.id, e)}
+                        aria-label="Mark as read"
+                        title="Mark as read"
+                    >
                                         <i className="fas fa-check"></i>
                                     </button>
                                 </div>


### PR DESCRIPTION
💡 What:
- Made notification items keyboard accessible by separating the clickable content from the "Mark as read" button.
- Added `role="button"` and `tabIndex="0"` to notification content when it has an action URL.
- Added `aria-label="Mark as read"` and `title="Mark as read"` to the mark-as-read button.
- Ensured keyboard navigation (Enter/Space) works for notification items.

🎯 Why:
- Previous implementation nested a button inside a clickable div, which is invalid HTML and confusing for screen readers.
- Keyboard-only users could not access notification actions or mark them as read easily.
- Screen reader users had no context for the "check" icon button.

♿ Accessibility:
- Valid ARIA roles and attributes.
- Keyboard support (Tab, Enter, Space).
- Accessible names for icon-only buttons.

---
*PR created automatically by Jules for task [11714012169271597198](https://jules.google.com/task/11714012169271597198) started by @lollito*