### PR TITLE
⚡ Bolt: Fix N+1 queries in match simulation injury checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-02-10 - Incremental Updates for Player Career Stats
-**Learning:** Avoiding full recalculations of aggregated data (like career stats) by using incremental updates saved significant database I/O in the hot path of match simulation.
-**Action:** Look for other places where aggregated data is recalculated from scratch instead of incrementally updated.
+## 2026-02-12 - Mockito Stubbing with Nulls
+**Learning:** When stubbing a method with `anyDouble()`, Mockito expects a non-null Double (or primitive double). If the code under test passes `null` (e.g. from a nullable DTO field), `anyDouble()` matcher fails with a strict stubbing mismatch or argument mismatch error.
+**Action:** Use `any()` or `nullable(Double.class)` when the argument can be null, or better yet, ensure the code under test handles nulls gracefully (e.g. defaulting to 0.0) so tests can use primitive matchers or explicit values. Also, when mocking DTOs that return wrappers (Double), remember default Mockito mocks return null/empty, and default constructors might leave fields as null.

--- a/src/main/java/com/lollito/fm/service/InjuryService.java
+++ b/src/main/java/com/lollito/fm/service/InjuryService.java
@@ -50,16 +50,6 @@ public class InjuryService {
     private Integer conditionThreshold;
 
     public boolean checkForInjury(Player player, Double matchIntensity) {
-        // Age factor (older players more prone)
-        double ageFactor = player.getAge() > ageThreshold ? 1.5 : 1.0;
-
-        // Condition factor (tired players more prone)
-        double conditionFactor = player.getCondition() < conditionThreshold ? 2.0 : 1.0;
-
-        // Previous injury factor
-        boolean hasHistory = !player.getInjuries().isEmpty();
-        double injuryHistoryFactor = hasHistory ? 1.3 : 1.0;
-
         // Staff bonus
         double injuryReduction = 0.0;
         if (player.getTeam() != null) {
@@ -71,10 +61,23 @@ public class InjuryService {
                 }
             }
         }
+        return checkForInjury(player, matchIntensity, injuryReduction);
+    }
+
+    public boolean checkForInjury(Player player, Double matchIntensity, Double injuryReduction) {
+        // Age factor (older players more prone)
+        double ageFactor = player.getAge() > ageThreshold ? 1.5 : 1.0;
+
+        // Condition factor (tired players more prone)
+        double conditionFactor = player.getCondition() < conditionThreshold ? 2.0 : 1.0;
+
+        // Previous injury factor
+        boolean hasHistory = !player.getInjuries().isEmpty();
+        double injuryHistoryFactor = hasHistory ? 1.3 : 1.0;
 
         double finalProbability = baseProbability * ageFactor *
                                 conditionFactor * injuryHistoryFactor *
-                                matchIntensity * (1.0 - injuryReduction);
+                                matchIntensity * (1.0 - (injuryReduction != null ? injuryReduction : 0.0));
 
         // Use ThreadLocalRandom for correct probability [0.0, 1.0)
         return ThreadLocalRandom.current().nextDouble() < finalProbability;

--- a/src/main/java/com/lollito/fm/service/StaffService.java
+++ b/src/main/java/com/lollito/fm/service/StaffService.java
@@ -245,6 +245,10 @@ public class StaffService {
 
     public StaffBonusesDTO calculateClubStaffBonuses(Long clubId) {
         Club club = clubService.findById(clubId);
+        return calculateClubStaffBonuses(club);
+    }
+
+    public StaffBonusesDTO calculateClubStaffBonuses(Club club) {
         List<Staff> activeStaff = club.getActiveStaff();
 
         double totalMotivationBonus = 0.0;

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
@@ -46,6 +46,7 @@ public class SimulationMatchServiceEventTest {
     @Mock private InjuryService injuryService;
     @Mock private RankingService rankingService;
     @Mock private AchievementService achievementService;
+    @Mock private StaffService staffService;
 
     private Match match;
     private Player playerWithNullCondition;
@@ -79,6 +80,7 @@ public class SimulationMatchServiceEventTest {
 
         // Mocks
         when(stadiumService.getCapacity(any())).thenReturn(10000);
+        when(staffService.calculateClubStaffBonuses(any(Club.class))).thenReturn(new com.lollito.fm.dto.StaffBonusesDTO());
 
         // Mock Formation Service to return valid formations
         when(formationService.createFormation(anyList(), any())).thenAnswer(invocation -> {

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceHomeAdvantageTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceHomeAdvantageTest.java
@@ -47,6 +47,7 @@ public class SimulationMatchServiceHomeAdvantageTest {
     @Mock private PlayerHistoryService playerHistoryService;
     @Mock private InjuryService injuryService;
     @Mock private AchievementService achievementService;
+    @Mock private StaffService staffService;
 
     @Test
     public void testHomeAdvantage_FullStadium() {
@@ -77,13 +78,14 @@ public class SimulationMatchServiceHomeAdvantageTest {
 
         // 2. Configure Mocks
         when(stadiumService.getCapacity(any())).thenReturn(capacity);
+        when(staffService.calculateClubStaffBonuses(any(Club.class))).thenReturn(new com.lollito.fm.dto.StaffBonusesDTO());
         when(formationService.createFormation(anyList(), any())).thenReturn(homeFormation).thenReturn(awayFormation);
         when(formationService.getDefender(any(Formation.class))).thenAnswer(i -> new ArrayList<>(((Formation)i.getArgument(0)).getPlayers().subList(0, 4)));
         when(formationService.getMiedfileder(any(Formation.class))).thenAnswer(i -> new ArrayList<>(((Formation)i.getArgument(0)).getPlayers().subList(4, 8)));
         when(formationService.getOffender(any(Formation.class))).thenAnswer(i -> new ArrayList<>(((Formation)i.getArgument(0)).getPlayers().subList(8, 11)));
         when(playerService.getOffenceAverage(anyList())).thenReturn(80);
         when(playerService.getDefenceAverage(anyList())).thenReturn(80);
-        when(injuryService.checkForInjury(any(), anyDouble())).thenReturn(false);
+        when(injuryService.checkForInjury(any(), anyDouble(), anyDouble())).thenReturn(false);
 
         // 3. Control Randomness
         try (MockedStatic<RandomUtils> mockedRandom = mockStatic(RandomUtils.class)) {

--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceTest.java
@@ -54,6 +54,7 @@ public class SimulationMatchServiceTest {
     @Mock private PlayerHistoryService playerHistoryService;
     @Mock private InjuryService injuryService;
     @Mock private AchievementService achievementService;
+    @Mock private StaffService staffService;
 
     @Test
     public void testSimulateMatchesBatch() {
@@ -88,6 +89,7 @@ public class SimulationMatchServiceTest {
 
         // 2. Configure Mocks
         when(stadiumService.getCapacity(any())).thenReturn(50000);
+        when(staffService.calculateClubStaffBonuses(any(Club.class))).thenReturn(new com.lollito.fm.dto.StaffBonusesDTO());
 
         // Mock formation creation for all
         when(formationService.createFormation(anyList(), any())).thenReturn(homeFormation1, awayFormation1, homeFormation2, awayFormation2);
@@ -132,6 +134,7 @@ public class SimulationMatchServiceTest {
 
         // Stadium
         when(stadiumService.getCapacity(any())).thenReturn(50000);
+        when(staffService.calculateClubStaffBonuses(any(Club.class))).thenReturn(new com.lollito.fm.dto.StaffBonusesDTO());
 
         // Formations
         when(formationService.createFormation(anyList(), any())).thenReturn(homeFormation).thenReturn(awayFormation);
@@ -156,7 +159,7 @@ public class SimulationMatchServiceTest {
         when(playerService.getDefenceAverage(anyList())).thenReturn(80);
 
         // Injury
-        when(injuryService.checkForInjury(any(), anyDouble())).thenReturn(false);
+        when(injuryService.checkForInjury(any(), anyDouble(), anyDouble())).thenReturn(false);
 
         // 3. Control Randomness
         try (MockedStatic<RandomUtils> mockedRandom = mockStatic(RandomUtils.class)) {


### PR DESCRIPTION
💡 What: Optimized injury checks during match simulation by pre-calculating staff bonuses at the club level instead of fetching them for every player.
🎯 Why: The original implementation performed a DB lookup (`clubRepository.findByTeam` and `staffService.calculateClubStaffBonuses`) for every player in every match (approx. 22+ queries per match). This caused an N+1 query problem, significantly slowing down batch simulations.
📊 Impact: Reduces DB queries for injury checks from ~22 per match to 2 per match (or 0 if clubs are already loaded). This significantly improves simulation performance for large batches of matches.
🔬 Measurement: Verified by running `mvn test` and ensuring `SimulationMatchService` tests pass. The logic change is a direct algorithmic improvement (moving loop-invariant calculation out of the loop).

---
*PR created automatically by Jules for task [9820918308695392131](https://jules.google.com/task/9820918308695392131) started by @lollito*