### PR TITLE
⚡ Bolt: Optimize SponsorshipService and RankingRepository fetching

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
@@ -1,5 +1,6 @@
 package com.lollito.fm.repository.rest;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,6 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
 	public Ranking findFirstByClubAndSeason(Club club, Season season);
 
+	@EntityGraph(attributePaths = {"club"})
 	public java.util.List<Ranking> findBySeason(Season season);
 }

--- a/src/main/java/com/lollito/fm/service/SponsorshipService.java
+++ b/src/main/java/com/lollito/fm/service/SponsorshipService.java
@@ -176,8 +176,7 @@ public class SponsorshipService {
         if (ranking == null) return null;
 
         // Calculate position
-        List<Ranking> allRankings = rankingRepository.findAll().stream() // Ideally findBySeason
-                .filter(r -> r.getSeason().getId().equals(currentSeason.getId()))
+        List<Ranking> allRankings = rankingRepository.findBySeason(currentSeason).stream()
                 .sorted((r1, r2) -> {
                     int p1 = r1.getPoints();
                     int p2 = r2.getPoints();

--- a/src/test/java/com/lollito/fm/service/SponsorshipServiceOptimizationTest.java
+++ b/src/test/java/com/lollito/fm/service/SponsorshipServiceOptimizationTest.java
@@ -1,0 +1,79 @@
+package com.lollito.fm.service;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.Club;
+import com.lollito.fm.model.Finance;
+import com.lollito.fm.model.Ranking;
+import com.lollito.fm.model.Season;
+import com.lollito.fm.model.Stadium;
+import com.lollito.fm.repository.rest.RankingRepository;
+import com.lollito.fm.repository.rest.SponsorRepository;
+import com.lollito.fm.repository.rest.SponsorshipOfferRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class SponsorshipServiceOptimizationTest {
+
+    @InjectMocks
+    private SponsorshipService sponsorshipService;
+
+    @Mock private RankingRepository rankingRepository;
+    @Mock private SeasonService seasonService;
+    @Mock private ClubService clubService;
+    @Mock private SponsorRepository sponsorRepository;
+    @Mock private SponsorshipOfferRepository sponsorshipOfferRepository;
+
+    @Test
+    public void testGenerateSponsorshipOffers_CallsFindAll() {
+        // Setup
+        Long clubId = 1L;
+        Club club = new Club();
+        club.setId(clubId);
+        club.setName("Test Club");
+        // Ensure club has necessary fields to avoid NPEs
+        Finance finance = new Finance();
+        finance.setBalance(BigDecimal.ZERO);
+        club.setFinance(finance);
+        Stadium stadium = new Stadium();
+        stadium.setCapacity(10000);
+        club.setStadium(stadium);
+
+        Season currentSeason = new Season();
+        currentSeason.setId(100L);
+
+        Ranking ranking = new Ranking();
+        ranking.setClub(club);
+        ranking.setSeason(currentSeason);
+        ranking.setPoints(10);
+
+        List<Ranking> allRankings = new ArrayList<>();
+        allRankings.add(ranking);
+
+        // Mocks
+        when(clubService.findById(clubId)).thenReturn(club);
+        when(seasonService.getCurrentSeason()).thenReturn(currentSeason);
+        when(rankingRepository.findByClubAndSeason(club, currentSeason)).thenReturn(ranking);
+        when(rankingRepository.findBySeason(currentSeason)).thenReturn(allRankings);
+        when(sponsorRepository.findAll()).thenReturn(new ArrayList<>()); // Just return empty sponsors
+        when(sponsorshipOfferRepository.saveAll(anyList())).thenReturn(new ArrayList<>());
+
+        // Execute
+        sponsorshipService.generateSponsorshipOffers(clubId);
+
+        // Verify
+        verify(rankingRepository).findBySeason(currentSeason);
+        verify(rankingRepository, org.mockito.Mockito.never()).findAll();
+    }
+}


### PR DESCRIPTION
This PR optimizes the `SponsorshipService` by replacing an inefficient `findAll()` call with a targeted `findBySeason()` query, significantly reducing memory usage and database load. It also adds an `@EntityGraph` to `RankingRepository.findBySeason` to eager-fetch the `club` association, resolving potential N+1 query issues in `RankingService`. A reproduction test is included to verify the fix.

---
*PR created automatically by Jules for task [14531257938734692212](https://jules.google.com/task/14531257938734692212) started by @lollito*