### PR TITLE
🔒 Fix hardcoded CORS allowed origins

### DIFF
--- a/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lollito/fm/config/security/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -49,6 +50,9 @@ public class WebSecurityConfig {
 	@Autowired
 	private AuthEntryPointJwt unauthorizedHandler;
 
+	@Value("${fm.app.cors.allowed-origins:http://localhost:3000,http://localhost:3001}")
+	private String[] allowedOrigins;
+
 	@Bean
 	public AuthTokenFilter authenticationJwtTokenFilter() {
 		return new AuthTokenFilter();
@@ -79,7 +83,7 @@ public class WebSecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:3001"));
+		configuration.setAllowedOrigins(Arrays.asList(allowedOrigins));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(Arrays.asList("content-type"));
 		configuration.setAllowCredentials(true);

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -40,3 +40,4 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 
 fm.app.jwtSecret=${FM_APP_JWT_SECRET}
 fm.app.jwtExpirationMs=${FM_APP_JWT_EXPIRATION_MS:86400000}
+fm.app.cors.allowed-origins=${ALLOWED_ORIGINS}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -188,3 +188,4 @@ fm.scheduling.match-processing.fixed-rate=60000
 # ScheduledTasks (General)
 fm.scheduling.general.initial-delay=180000
 fm.scheduling.general.fixed-rate=60000
+fm.app.cors.allowed-origins=http://localhost:3000,http://localhost:3001

--- a/src/test/java/com/lollito/fm/config/security/WebSecurityConfigTest.java
+++ b/src/test/java/com/lollito/fm/config/security/WebSecurityConfigTest.java
@@ -1,0 +1,37 @@
+package com.lollito.fm.config.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class WebSecurityConfigTest {
+
+    @Autowired
+    private CorsConfigurationSource corsConfigurationSource;
+
+    @Test
+    public void testCorsConfiguration() {
+        assertNotNull(corsConfigurationSource, "CorsConfigurationSource bean should be present");
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        CorsConfiguration config = corsConfigurationSource.getCorsConfiguration(request);
+
+        assertNotNull(config, "CorsConfiguration should not be null");
+
+        List<String> allowedOrigins = config.getAllowedOrigins();
+        assertNotNull(allowedOrigins, "Allowed origins should not be null");
+
+        // Verify default values from application.properties
+        assertTrue(allowedOrigins.contains("http://localhost:3000"), "Should contain http://localhost:3000");
+        assertTrue(allowedOrigins.contains("http://localhost:3001"), "Should contain http://localhost:3001");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded CORS allowed origins in `WebSecurityConfig.java`.

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded origins limit flexibility and security. If the application is deployed to an environment where the hardcoded origins are not appropriate, it could either break functionality (CORS errors) or allow unauthorized access if the hardcoded origins are too permissive or incorrect for the target environment. It also necessitates a code recompilation to change allowed origins.

🛡️ **Solution:** How the fix addresses the vulnerability
The allowed origins are now injected from the `fm.app.cors.allowed-origins` configuration property.
-   Defaults to `http://localhost:3000,http://localhost:3001` in `application.properties` for development.
-   Configured to use the `${ALLOWED_ORIGINS}` environment variable in `application-prod.properties` for production flexibility and security.
-   Verified with a new integration test `WebSecurityConfigTest`.

---
*PR created automatically by Jules for task [1437735413221218960](https://jules.google.com/task/1437735413221218960) started by @lollito*