### PR TITLE
🔒 Fix exposed Redis port in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     container_name: fm-redis
     restart: unless-stopped
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
       - ./docker/redis/redis.conf:/usr/local/etc/redis/redis.conf


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the exposed Redis port (6379) in `docker-compose.yml`. The original configuration `6379:6379` exposed the port to all interfaces (0.0.0.0).

⚠️ **Risk:** If left unfixed, the Redis instance could be accessed by unauthorized users on the same network (or internet if the host is public), potentially leading to data leakage or manipulation.

🛡️ **Solution:** The port mapping was changed to `127.0.0.1:6379:6379`, binding it strictly to the localhost interface. This ensures that only the host machine (and internal docker containers via the docker network) can access Redis, while blocking external access. Note that the backend application does not currently appear to use Redis, but this fix secures the infrastructure configuration regardless.

---
*PR created automatically by Jules for task [17565048583710312118](https://jules.google.com/task/17565048583710312118) started by @lollito*