### PR TITLE
Fix EventHistory match reference bug

### DIFF
--- a/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
+++ b/src/test/java/com/lollito/fm/service/SimulationMatchServiceEventTest.java
@@ -127,7 +127,7 @@ public class SimulationMatchServiceEventTest {
     }
 
     @Test
-    public void testEventPersistenceReference() {
+    public void testEventPersistenceReferenceIsCorrect() {
         // Run simulation
         simulationMatchService.simulate(match);
 
@@ -135,8 +135,7 @@ public class SimulationMatchServiceEventTest {
         List<EventHistory> events = match.getEvents();
         assertFalse(events.isEmpty(), "Events should be generated");
 
-        // Verify the BUG: Check if events have match reference set
-        // Expecting this to FAIL currently if the bug exists
+        // Verify that EventHistory objects have the correct match reference set
         for (EventHistory event : events) {
              assertNotNull(event.getMatch(), "EventHistory.match reference should not be null");
              assertEquals(match, event.getMatch(), "EventHistory.match should point to the match object");


### PR DESCRIPTION
Verified that the bug where EventHistory objects created during match simulation do not have their match reference set is already fixed in the codebase. The `Match.addEvents()` method correctly iterates over the provided events and sets the match reference. Updated the provided reproduction test `SimulationMatchServiceEventTest.java` to remove comments expecting failure and renamed the test method to `testEventPersistenceReferenceIsCorrect` to serve as a proper regression test. The test passes successfully.

---
*PR created automatically by Jules for task [13278356462509626460](https://jules.google.com/task/13278356462509626460) started by @lollito*