### PR TITLE
🧪 Add tests for TeamService.findById exception handling

### DIFF
--- a/src/test/java/com/lollito/fm/service/TeamServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/TeamServiceTest.java
@@ -1,0 +1,66 @@
+package com.lollito.fm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lollito.fm.model.Team;
+import com.lollito.fm.repository.rest.TeamRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private PlayerService playerService;
+
+    @Mock
+    private NameService nameService;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    void findById_ShouldThrowException_WhenTeamNotFound() {
+        // Arrange
+        when(teamRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> teamService.findById(1L));
+        assertEquals("Team not found", exception.getMessage());
+
+        verify(teamRepository).findById(1L);
+    }
+
+    @Test
+    void findById_ShouldReturnTeam_WhenTeamFound() {
+        // Arrange
+        Long teamId = 1L;
+        Team mockTeam = new Team();
+        mockTeam.setId(teamId);
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(mockTeam));
+
+        // Act
+        Team result = teamService.findById(teamId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(teamId, result.getId());
+        assertEquals(mockTeam, result);
+
+        verify(teamRepository).findById(teamId);
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for `TeamService.findById` method.
It specifically targets the requirement to verify that a `RuntimeException` with the message "Team not found" is thrown when the team does not exist.
Additionally, it includes a happy path test case to verify successful team retrieval.
Dependencies `TeamRepository`, `PlayerService`, and `NameService` are mocked.
Existing test failures in `FmApplicationTests` and `MatchSchedulerServiceTest` were verified to be pre-existing and unrelated to these changes.

---
*PR created automatically by Jules for task [7175998948304584627](https://jules.google.com/task/7175998948304584627) started by @lollito*