### PR TITLE
🔒 Fix Insecure WebSocket Origin Configuration

### DIFF
--- a/src/main/java/com/lollito/fm/config/WebSocketConfig.java
+++ b/src/main/java/com/lollito/fm/config/WebSocketConfig.java
@@ -20,7 +20,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/live-match")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns("http://localhost:3000", "http://localhost:3001")
                 .withSockJS();
     }
 }

--- a/src/test/java/com/lollito/fm/config/WebSocketConfigTest.java
+++ b/src/test/java/com/lollito/fm/config/WebSocketConfigTest.java
@@ -1,0 +1,36 @@
+package com.lollito.fm.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.StompWebSocketEndpointRegistration;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class WebSocketConfigTest {
+
+    @Mock
+    private StompEndpointRegistry registry;
+
+    @Mock
+    private StompWebSocketEndpointRegistration registration;
+
+    @Test
+    public void registerStompEndpoints_ShouldConfigureAllowedOriginPatterns() {
+        WebSocketConfig webSocketConfig = new WebSocketConfig();
+
+        when(registry.addEndpoint("/ws/live-match")).thenReturn(registration);
+        when(registration.setAllowedOriginPatterns(anyString(), anyString())).thenReturn(registration);
+
+        webSocketConfig.registerStompEndpoints(registry);
+
+        verify(registry).addEndpoint("/ws/live-match");
+        verify(registration).setAllowedOriginPatterns("http://localhost:3000", "http://localhost:3001");
+        verify(registration).withSockJS();
+    }
+}


### PR DESCRIPTION
This PR addresses a security vulnerability in the WebSocket configuration where `setAllowedOriginPatterns("*")` allowed any origin to connect to the WebSocket endpoint.

**Risk:**
Allowing all origins enables Cross-Site WebSocket Hijacking (CSWSH), where a malicious site can establish a WebSocket connection to the application on behalf of a victim user.

**Solution:**
The configuration has been updated to explicitly allow only trusted origins:
- `http://localhost:3000` (likely the frontend)
- `http://localhost:3001` (likely admin or secondary service)

These origins match the existing CORS configuration in `WebSecurityConfig`.

**Verification:**
- A new unit test `WebSocketConfigTest` was added to verify that `setAllowedOriginPatterns` is called with the correct values.
- Existing tests were run to ensure no regressions (confirmed that existing failures are pre-existing).

---
*PR created automatically by Jules for task [4276867188672905570](https://jules.google.com/task/4276867188672905570) started by @lollito*