### PR TITLE
🔒 Fix missing access control in LiveMatchController

### DIFF
--- a/src/main/java/com/lollito/fm/controller/LiveMatchController.java
+++ b/src/main/java/com/lollito/fm/controller/LiveMatchController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import com.lollito.fm.model.dto.LiveMatchSummaryDTO;
 import com.lollito.fm.service.LiveMatchService;
@@ -48,12 +49,14 @@ public class LiveMatchController {
     }
 
     @PostMapping("/{id}/finish")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> finishLiveMatch(@PathVariable Long id) {
         liveMatchService.forceFinish(id);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{id}/reset")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> resetLiveMatch(@PathVariable Long id) {
         liveMatchService.reset(id);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/lollito/fm/controller/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/com/lollito/fm/controller/rest/errors/ExceptionTranslator.java
@@ -7,8 +7,7 @@ import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
-//TODO uncomment when import spring-security
-//import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -48,13 +47,12 @@ public class ExceptionTranslator {
         return ex.getErrorVM();
     }
 
-    //TODO uncomment when import spring-security
-//    @ExceptionHandler(AccessDeniedException.class)
-//    @ResponseStatus(HttpStatus.FORBIDDEN)
-//    @ResponseBody
-//    public ErrorVM processAccessDeniedException(AccessDeniedException e) {
-//        return new ErrorVM(ErrorConstants.ERR_ACCESS_DENIED, e.getMessage());
-//    }
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ResponseBody
+    public ErrorVM processAccessDeniedException(AccessDeniedException e) {
+        return new ErrorVM(ErrorConstants.ERR_ACCESS_DENIED, e.getMessage());
+    }
 
     private ErrorVM processFieldErrors(List<FieldError> fieldErrors) {
         ErrorVM dto = new ErrorVM(ErrorConstants.ERR_VALIDATION);

--- a/src/test/java/com/lollito/fm/controller/LiveMatchControllerTest.java
+++ b/src/test/java/com/lollito/fm/controller/LiveMatchControllerTest.java
@@ -1,0 +1,74 @@
+package com.lollito.fm.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.lollito.fm.config.security.WebSecurityConfig;
+import com.lollito.fm.config.security.jwt.AuthEntryPointJwt;
+import com.lollito.fm.config.security.jwt.JwtUtils;
+import com.lollito.fm.service.LiveMatchService;
+import com.lollito.fm.service.UserDetailsServiceImpl;
+import com.lollito.fm.service.UserService;
+
+@WebMvcTest(controllers = LiveMatchController.class)
+@Import(WebSecurityConfig.class)
+public class LiveMatchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LiveMatchService liveMatchService;
+
+    @MockBean
+    private UserService userService; // Often required by security config
+
+    @MockBean
+    private AuthEntryPointJwt authEntryPointJwt;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean(name = "userDetailsServiceImpl")
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    public void testFinishLiveMatchAsUser() throws Exception {
+        mockMvc.perform(post("/api/live-match/1/finish").with(csrf()))
+               .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void testFinishLiveMatchAsAdmin() throws Exception {
+        doNothing().when(liveMatchService).forceFinish(1L);
+        mockMvc.perform(post("/api/live-match/1/finish").with(csrf()))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER"})
+    public void testResetLiveMatchAsUser() throws Exception {
+        mockMvc.perform(post("/api/live-match/1/reset").with(csrf()))
+               .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void testResetLiveMatchAsAdmin() throws Exception {
+        doNothing().when(liveMatchService).reset(1L);
+        mockMvc.perform(post("/api/live-match/1/reset").with(csrf()))
+               .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
This PR addresses a security vulnerability where `finishLiveMatch` and `resetLiveMatch` endpoints in `LiveMatchController` were accessible to any authenticated user.

Changes:
1.  **Access Control**: Added `@PreAuthorize("hasRole('ADMIN')")` to `finishLiveMatch` and `resetLiveMatch` methods in `LiveMatchController.java` to restrict access to administrators only.
2.  **Exception Handling**: Uncommented the `AccessDeniedException` handler in `ExceptionTranslator.java`. This ensures that when an access denied exception occurs (such as when a non-admin user tries to access these endpoints), the API returns a proper `403 Forbidden` status code instead of a `500 Internal Server Error`.
3.  **Testing**: Added `LiveMatchControllerTest.java` with tests to verify:
    *   Users with `USER` role receive a `403 Forbidden` response when attempting to access these endpoints.
    *   Users with `ADMIN` role receive a `200 OK` response.
    *   Verified that the fix works as expected and regression tests pass.

---
*PR created automatically by Jules for task [7960756647386908694](https://jules.google.com/task/7960756647386908694) started by @lollito*