### PR TITLE
Add shortName field to Club entity

### DIFF
--- a/src/main/java/com/lollito/fm/model/Club.java
+++ b/src/main/java/com/lollito/fm/model/Club.java
@@ -50,6 +50,8 @@ public class Club implements Serializable{
 	private Long id;
 	
     private String name;
+
+    private String shortName;
     
     private LocalDate foundation;
 

--- a/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
+++ b/src/main/java/com/lollito/fm/model/dto/ClubDTO.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class ClubDTO {
     private Long id;
     private String name;
+    private String shortName;
     private LocalDate foundation;
     private String city;
     private String logoURL;

--- a/src/main/java/com/lollito/fm/service/AdminService.java
+++ b/src/main/java/com/lollito/fm/service/AdminService.java
@@ -114,11 +114,7 @@ public class AdminService {
         // Create club
         Club club = new Club();
         club.setName(request.getName());
-        // club.setShortName(request.getShortName()); // Club entity might not have shortName, checking model... assumed it has or I check Club.java
-        // Club.java read earlier? I read ClubService.java. Let's assume standard fields.
-        // If compilation fails, I will fix. ClubService uses setName, setFoundation, setLogoURL, setStadium, setFinance, setTeam.
-        // It doesn't seem to have shortName in ClubService.createClub.
-        // I'll check Club.java if needed but I'll proceed.
+        club.setShortName(request.getShortName());
         club.setFoundation(java.time.LocalDate.of(request.getFoundedYear(), 1, 1));
         club.setCity(request.getCity());
 
@@ -186,7 +182,7 @@ public class AdminService {
         String oldValues = convertToJson(club); // Simplified, ideally deep copy or select fields
 
         if (request.getName() != null) club.setName(request.getName());
-        // club.setShortName(request.getShortName()); // Assuming Club has shortName if added, else ignore
+        if (request.getShortName() != null) club.setShortName(request.getShortName());
         if (request.getFoundedYear() != null) club.setFoundation(java.time.LocalDate.of(request.getFoundedYear(), 1, 1));
         if (request.getCity() != null) club.setCity(request.getCity());
 


### PR DESCRIPTION
This PR adds the `shortName` field to the `Club` entity and `ClubDTO` to support short names for clubs. It also enables the previously commented-out code in `AdminService` to populate this field during club creation and update. This addresses the issue where the field was missing from the entity model but expected by the service layer.

---
*PR created automatically by Jules for task [1292689296739045435](https://jules.google.com/task/1292689296739045435) started by @lollito*