### PR TITLE
Improve match notification tracking

### DIFF
--- a/src/main/java/com/lollito/fm/model/WatchlistNotification.java
+++ b/src/main/java/com/lollito/fm/model/WatchlistNotification.java
@@ -48,6 +48,8 @@ public class WatchlistNotification {
     // Context data (JSON)
     private String contextData;
 
+    private Long matchId;
+
     @Enumerated(EnumType.STRING)
     private NotificationSeverity severity; // INFO, WARNING, IMPORTANT, CRITICAL
 }

--- a/src/main/java/com/lollito/fm/repository/WatchlistNotificationRepository.java
+++ b/src/main/java/com/lollito/fm/repository/WatchlistNotificationRepository.java
@@ -9,9 +9,12 @@ import org.springframework.stereotype.Repository;
 
 import com.lollito.fm.model.Watchlist;
 import com.lollito.fm.model.WatchlistNotification;
+import com.lollito.fm.model.WatchlistEntry;
 
 @Repository
 public interface WatchlistNotificationRepository extends JpaRepository<WatchlistNotification, Long> {
+
+    boolean existsByWatchlistEntryAndMatchId(WatchlistEntry watchlistEntry, Long matchId);
 
     @Query("SELECT n FROM WatchlistNotification n WHERE n.watchlistEntry.watchlist = :watchlist ORDER BY n.createdDate DESC")
     List<WatchlistNotification> findByWatchlistOrderByCreatedDateDesc(@Param("watchlist") Watchlist watchlist);

--- a/src/main/java/com/lollito/fm/service/WatchlistService.java
+++ b/src/main/java/com/lollito/fm/service/WatchlistService.java
@@ -259,7 +259,7 @@ public class WatchlistService {
                 NotificationSeverity.IMPORTANT : NotificationSeverity.INFO;
 
             createWatchlistNotification(entry, WatchlistNotificationType.PRICE_CHANGE,
-                                      title, message, severity);
+                                      title, message, severity, null);
         }
 
         // Update entry with new value
@@ -305,10 +305,7 @@ public class WatchlistService {
     }
 
     private boolean hasNotifiedAboutMatch(WatchlistEntry entry, Match match) {
-        // Implementation check
-        // e.g. check if any notification of type MATCH_PERFORMANCE exists created after match date
-        // with contextData containing matchId
-        return false; // Placeholder
+        return notificationRepository.existsByWatchlistEntryAndMatchId(entry, match.getId());
     }
 
     /**
@@ -330,7 +327,7 @@ public class WatchlistService {
             NotificationSeverity.IMPORTANT : NotificationSeverity.INFO;
 
         createWatchlistNotification(entry, WatchlistNotificationType.MATCH_PERFORMANCE,
-                                  title, message, severity);
+                                  title, message, severity, match.getId());
     }
 
     /**
@@ -438,7 +435,8 @@ public class WatchlistService {
      */
     private void createWatchlistNotification(WatchlistEntry entry, WatchlistNotificationType type,
                                            String title, String message,
-                                           NotificationSeverity severity) {
+                                           NotificationSeverity severity,
+                                           Long matchId) {
         WatchlistNotification notification = WatchlistNotification.builder()
             .watchlistEntry(entry)
             .type(type)
@@ -449,6 +447,7 @@ public class WatchlistService {
             .isImportant(severity == NotificationSeverity.IMPORTANT ||
                         severity == NotificationSeverity.CRITICAL)
             .severity(severity)
+            .matchId(matchId)
             .build();
 
         notificationRepository.save(notification);

--- a/src/test/java/com/lollito/fm/service/WatchlistServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/WatchlistServiceTest.java
@@ -3,15 +3,19 @@ package com.lollito.fm.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import com.lollito.fm.model.Match;
+import com.lollito.fm.model.MatchPlayerStats;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -130,6 +134,60 @@ class WatchlistServiceTest {
             watchlistService.addPlayerToWatchlist(club.getId(), 1L, request))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Watchlist is full");
+    }
+
+    @Test
+    void testProcessRecentPerformances_NoDuplicateNotifications() {
+        // Setup config values
+        ReflectionTestUtils.setField(watchlistService, "valueChangeThreshold", 0.05);
+
+        // Setup
+        WatchlistEntry entry = createTestWatchlistEntry();
+        entry.setNotifyOnPerformance(true);
+        // Ensure initial values match current values to avoid other notifications
+        entry.setAddedValue(BigDecimal.ZERO);
+        entry.setCurrentValue(BigDecimal.ZERO);
+        entry.setAddedRating(0.0);
+        entry.setCurrentRating(0.0);
+
+        // Mock calculatePlayerValue to return 0 to match
+        // But calculatePlayerValue uses player.getAverage(), so let's set player stats to 0
+        entry.getPlayer().setStamina(0.0); // Assuming average depends on stats.
+        // Or simpler: processWatchlistEntryUpdates calls calculatePlayerValue(player).
+        // Since we can't easily mock private method, let's rely on null/0 checks.
+        // Actually, createTestPlayer sets Stamina 80.
+        // calculatePlayerValue returns (avg * 1000000).
+        // If we set entry.currentValue to that value, no change will be detected.
+        // But calculation is internal.
+
+        // Better approach: mock findAllActive to return our entry.
+        when(watchlistEntryRepository.findAllActive()).thenReturn(List.of(entry));
+
+        Match match = new Match();
+        match.setId(100L);
+        Club home = new Club(); home.setName("Home FC"); match.setHome(home);
+        Club away = new Club(); away.setName("Away FC"); match.setAway(away);
+
+        MatchPlayerStats stats = new MatchPlayerStats();
+        stats.setMatch(match);
+        stats.setGoals(3); // Notable performance (hat-trick)
+        stats.setRating(9.5);
+
+        when(matchPlayerStatsRepository.findRecentStats(any(), any())).thenReturn(List.of(stats));
+
+        // Case 1: Notification already exists
+        when(notificationRepository.existsByWatchlistEntryAndMatchId(entry, match.getId())).thenReturn(true);
+
+        watchlistService.processDailyWatchlistUpdates();
+
+        verify(notificationRepository, never()).save(any(WatchlistNotification.class));
+
+        // Case 2: Notification does not exist
+        when(notificationRepository.existsByWatchlistEntryAndMatchId(entry, match.getId())).thenReturn(false);
+
+        watchlistService.processDailyWatchlistUpdates();
+
+        verify(notificationRepository).save(any(WatchlistNotification.class));
     }
 
     private Club createTestClub() {


### PR DESCRIPTION
This PR improves the robustness of match performance notifications in `WatchlistService`. Previously, the duplicate check was a placeholder or relied on "hacky" logic. I have introduced a `matchId` field to the `WatchlistNotification` entity and a corresponding existence check in the repository. This ensures that users do not receive multiple notifications for the same match performance. A unit test has been added to verify this behavior.

---
*PR created automatically by Jules for task [11980702294730173524](https://jules.google.com/task/11980702294730173524) started by @lollito*