### PR TITLE
⚡ Bolt: Optimize ranking loading to eliminate N+1 queries

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
@@ -17,4 +17,7 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
 	@EntityGraph(attributePaths = {"club"})
 	public java.util.List<Ranking> findBySeason(Season season);
+
+	@EntityGraph(attributePaths = {"club", "club.user"})
+	public java.util.List<Ranking> findDistinctBySeasonOrderByPointsDesc(Season season);
 }

--- a/src/main/java/com/lollito/fm/service/RankingService.java
+++ b/src/main/java/com/lollito/fm/service/RankingService.java
@@ -82,7 +82,8 @@ public class RankingService {
 	public List<Ranking> load(){
 		User user = userService.getLoggedUser();
 		if (user != null && user.getClub() != null) {
-			return user.getClub().getLeague().getCurrentSeason().getRankingLines();
+			Season season = user.getClub().getLeague().getCurrentSeason();
+			return rankingLineRepository.findDistinctBySeasonOrderByPointsDesc(season);
 		}
 		return Collections.emptyList();
 	}

--- a/src/test/java/com/lollito/fm/service/RankingServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/RankingServiceTest.java
@@ -1,6 +1,7 @@
 package com.lollito.fm.service;
 
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -18,12 +19,16 @@ import com.lollito.fm.model.Ranking;
 import com.lollito.fm.model.User;
 import com.lollito.fm.model.League;
 import com.lollito.fm.model.Season;
+import com.lollito.fm.repository.rest.RankingRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class RankingServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private RankingRepository rankingLineRepository;
 
     @InjectMocks
     private RankingService rankingService;
@@ -52,12 +57,13 @@ public class RankingServiceTest {
         Season season = new Season();
         Ranking ranking = new Ranking();
 
-        season.setRankingLines(Collections.singletonList(ranking));
+        // Old logic setup (still needed for traversing to get season)
         league.setCurrentSeason(season);
         club.setLeague(league);
         user.setClub(club);
 
         when(userService.getLoggedUser()).thenReturn(user);
+        when(rankingLineRepository.findDistinctBySeasonOrderByPointsDesc(season)).thenReturn(Collections.singletonList(ranking));
 
         // Execute
         List<Ranking> rankings = rankingService.load();
@@ -65,5 +71,6 @@ public class RankingServiceTest {
         // Verify
         assertNotNull(rankings);
         assertEquals(1, rankings.size());
+        verify(rankingLineRepository).findDistinctBySeasonOrderByPointsDesc(season);
     }
 }


### PR DESCRIPTION
⚡ Bolt: Optimize ranking loading to eliminate N+1 queries

💡 What:
Introduced `findDistinctBySeasonOrderByPointsDesc` in `RankingRepository` with `@EntityGraph(attributePaths = {"club", "club.user"})`.
Updated `RankingService.load()` to use this method instead of traversing the object graph.

🎯 Why:
The previous implementation traversed `user.getClub().getLeague().getCurrentSeason().getRankingLines()`, which lazily loaded rankings.
When these rankings were mapped to DTOs, `ClubMapper` accessed `club.getUser()` to set `isHuman`.
Since `Club.user` is a `mappedBy` OneToOne relationship, accessing it triggered a separate database query for each club (N+1 problem).
This optimization reduces the operation to a single query.

📊 Impact:
Significantly reduces database round-trips when loading the league table, especially for leagues with many teams.

🔬 Measurement:
Verified by `RankingServiceTest` which mocks the repository call. Ideally, integration tests with query logging would confirm the exact query count reduction.

---
*PR created automatically by Jules for task [14162791712644794409](https://jules.google.com/task/14162791712644794409) started by @lollito*