### PR TITLE
⚡ Bolt: Optimize ranking loading to prevent N+1 queries

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
@@ -17,4 +17,7 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
 	@EntityGraph(attributePaths = {"club"})
 	public java.util.List<Ranking> findBySeason(Season season);
+
+	@EntityGraph(attributePaths = {"club", "club.user"})
+	public java.util.List<Ranking> findBySeasonOrderByPointsDesc(Season season);
 }

--- a/src/main/java/com/lollito/fm/service/RankingService.java
+++ b/src/main/java/com/lollito/fm/service/RankingService.java
@@ -82,7 +82,8 @@ public class RankingService {
 	public List<Ranking> load(){
 		User user = userService.getLoggedUser();
 		if (user != null && user.getClub() != null) {
-			return user.getClub().getLeague().getCurrentSeason().getRankingLines();
+			Season season = user.getClub().getLeague().getCurrentSeason();
+			return rankingLineRepository.findBySeasonOrderByPointsDesc(season);
 		}
 		return Collections.emptyList();
 	}

--- a/src/test/java/com/lollito/fm/service/RankingServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/RankingServiceTest.java
@@ -1,5 +1,6 @@
 package com.lollito.fm.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,12 +19,16 @@ import com.lollito.fm.model.Ranking;
 import com.lollito.fm.model.User;
 import com.lollito.fm.model.League;
 import com.lollito.fm.model.Season;
+import com.lollito.fm.repository.rest.RankingRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class RankingServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private RankingRepository rankingLineRepository;
 
     @InjectMocks
     private RankingService rankingService;
@@ -58,6 +63,8 @@ public class RankingServiceTest {
         user.setClub(club);
 
         when(userService.getLoggedUser()).thenReturn(user);
+        when(rankingLineRepository.findBySeasonOrderByPointsDesc(any(Season.class)))
+                .thenReturn(Collections.singletonList(ranking));
 
         // Execute
         List<Ranking> rankings = rankingService.load();


### PR DESCRIPTION
This PR addresses a significant performance bottleneck in the `RankingService.load()` method.

Previously, loading the rankings involved traversing the object graph:
`user.getClub().getLeague().getCurrentSeason().getRankingLines()`.
This triggered N+1 queries because `Ranking.club` and `Club.user` are lazy-loaded. For a league with 20 clubs, this resulted in approximately 41 queries per request.

I have implemented the following changes:
1.  Added `findBySeasonOrderByPointsDesc` to `RankingRepository` with `@EntityGraph(attributePaths = {"club", "club.user"})`. This ensures that `Ranking`, `Club`, and `User` are fetched in a single query.
2.  Updated `RankingService.load()` to use this optimized repository method.
3.  Updated unit tests to reflect these changes.

This optimization significantly reduces database load and improves response time for the ranking endpoint.

---
*PR created automatically by Jules for task [526728700766343831](https://jules.google.com/task/526728700766343831) started by @lollito*