### PR TITLE
⚡ Bolt: Optimize ManagerProfile fetching to reduce DB queries

### DIFF
--- a/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
+++ b/src/main/java/com/lollito/fm/service/ManagerProgressionService.java
@@ -26,6 +26,11 @@ public class ManagerProgressionService {
 
     @Transactional
     public ManagerProfile getProfile(User user) {
+        // Optimization: Use the ManagerProfile from the User object if available to avoid a database query.
+        // ManagerProfile is loaded eagerly with User (default @OneToOne behavior) and unlockedPerks is also EAGER.
+        if (user.getManagerProfile() != null) {
+            return user.getManagerProfile();
+        }
         return managerProfileRepository.findByUserId(user.getId())
                 .orElseGet(() -> createProfile(user));
     }
@@ -110,6 +115,11 @@ public class ManagerProgressionService {
 
     @Transactional(readOnly = true)
     public boolean hasPerk(User user, ManagerPerk perk) {
+        // Optimization: Use the ManagerProfile from the User object if available to avoid a database query.
+        // ManagerProfile is loaded eagerly with User (default @OneToOne behavior) and unlockedPerks is also EAGER.
+        if (user.getManagerProfile() != null) {
+            return user.getManagerProfile().getUnlockedPerks().contains(perk);
+        }
         return managerProfileRepository.findByUserId(user.getId())
                 .map(profile -> profile.getUnlockedPerks().contains(perk))
                 .orElse(false);

--- a/src/test/java/com/lollito/fm/service/ManagerProgressionServiceTest.java
+++ b/src/test/java/com/lollito/fm/service/ManagerProgressionServiceTest.java
@@ -208,4 +208,18 @@ public class ManagerProgressionServiceTest {
 
         assertFalse(managerProgressionService.hasPerk(user, ManagerPerk.VIDEO_ANALYST));
     }
+
+    @Test
+    void hasPerk_ShouldUseUserObject_WhenProfileIsPresent() {
+        // Arrange
+        profile.getUnlockedPerks().add(ManagerPerk.VIDEO_ANALYST);
+        user.setManagerProfile(profile);
+
+        // Act
+        boolean result = managerProgressionService.hasPerk(user, ManagerPerk.VIDEO_ANALYST);
+
+        // Assert
+        assertTrue(result);
+        verify(managerProfileRepository, never()).findByUserId(any());
+    }
 }


### PR DESCRIPTION
⚡ Bolt: Optimized ManagerProfile fetching in ManagerProgressionService

💡 What:
Refactored `ManagerProgressionService.hasPerk` and `getProfile` to prioritize using the `ManagerProfile` already loaded on the `User` object (via EAGER fetch) instead of always querying `ManagerProfileRepository`.

🎯 Why:
`hasPerk` is called repeatedly during match simulation (e.g. for `FORTRESS` and `MOTIVATOR` perks). Previously, it triggered a database query for every check (4+ queries per match). Since `User` is often already loaded with its `ManagerProfile` (due to default `@OneToOne` eager fetching), these queries were redundant.

📊 Impact:
Reduces database queries by 4 per match simulation. For a round of 10 matches, this saves 40 queries.

🔬 Measurement:
Verified with a new unit test `hasPerk_ShouldUseUserObject_WhenProfileIsPresent` which asserts that `managerProfileRepository.findByUserId` is NOT called when the profile is set on the user. Full test suite passed (ignoring unrelated pre-existing failures).

---
*PR created automatically by Jules for task [732758940474787291](https://jules.google.com/task/732758940474787291) started by @lollito*