### PR TITLE
🎨 Palette: Improved Register Form UX

### DIFF
--- a/fm-web/src/pages/Register.js
+++ b/fm-web/src/pages/Register.js
@@ -18,6 +18,7 @@ const Register = () => {
   });
   const [countries, setCountries] = useState([]);
   const [servers, setServers] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
   const { login } = useContext(AuthContext);
   const navigate = useNavigate();
 
@@ -59,12 +60,16 @@ const Register = () => {
       showToast('Passwords do not match', 'error');
       return;
     }
+
+    setIsLoading(true);
     try {
       const response = await api.post('/user/register', formData);
       login(response.data);
       navigate('/');
     } catch (error) {
       showToast('Registration failed', 'error');
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -75,8 +80,9 @@ const Register = () => {
           <h2 className="card-title text-center" style={{ textAlign: 'center', color: 'var(--accent-color)' }}>FM Register</h2>
           <form onSubmit={handleSubmit}>
             <div className="form-group">
-              <label>Username</label>
+              <label htmlFor="username">Username</label>
               <input
+                id="username"
                 type="text"
                 name="username"
                 className="form-control"
@@ -84,11 +90,13 @@ const Register = () => {
                 value={formData.username}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
             <div className="form-group">
-              <label>Email address</label>
+              <label htmlFor="email">Email address</label>
               <input
+                id="email"
                 type="email"
                 name="email"
                 className="form-control"
@@ -96,11 +104,13 @@ const Register = () => {
                 value={formData.email}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
             <div className="form-group">
-              <label>Repeat Email address</label>
+              <label htmlFor="emailConfirm">Repeat Email address</label>
               <input
+                id="emailConfirm"
                 type="email"
                 name="emailConfirm"
                 className="form-control"
@@ -108,11 +118,13 @@ const Register = () => {
                 value={formData.emailConfirm}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
             <div className="form-group">
-              <label>Password</label>
+              <label htmlFor="password">Password</label>
               <input
+                id="password"
                 type="password"
                 name="password"
                 className="form-control"
@@ -120,11 +132,13 @@ const Register = () => {
                 value={formData.password}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
             <div className="form-group">
-              <label>Repeat Password</label>
+              <label htmlFor="passwordConfirm">Repeat Password</label>
               <input
+                id="passwordConfirm"
                 type="password"
                 name="passwordConfirm"
                 className="form-control"
@@ -132,16 +146,19 @@ const Register = () => {
                 value={formData.passwordConfirm}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
             <div className="form-group">
-              <label>Country</label>
+              <label htmlFor="countryId">Country</label>
               <select
+                id="countryId"
                 name="countryId"
                 className="form-control"
                 value={formData.countryId}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               >
                 <option value="">Select Country</option>
                 {countries.map(c => (
@@ -150,13 +167,15 @@ const Register = () => {
               </select>
             </div>
             <div className="form-group">
-                <label>Server</label>
+                <label htmlFor="serverId">Server</label>
                 <select
+                  id="serverId"
                   name="serverId"
                   className="form-control"
                   value={formData.serverId}
                   onChange={handleChange}
                   required
+                  disabled={isLoading}
                 >
                   <option value="">Select Server</option>
                   {servers.map(s => (
@@ -165,8 +184,9 @@ const Register = () => {
                 </select>
               </div>
             <div className="form-group">
-              <label>Club Name</label>
+              <label htmlFor="clubName">Club Name</label>
               <input
+                id="clubName"
                 type="text"
                 name="clubName"
                 className="form-control"
@@ -174,9 +194,26 @@ const Register = () => {
                 value={formData.clubName}
                 onChange={handleChange}
                 required
+                disabled={isLoading}
               />
             </div>
-            <button className="btn btn-primary" style={{ width: '100%' }} type="submit">Create Account</button>
+            <button
+              className="btn btn-primary"
+              style={{ width: '100%' }}
+              type="submit"
+              disabled={isLoading}
+              aria-busy={isLoading}
+            >
+              {isLoading ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                  <span className="visually-hidden">Loading...</span>
+                  Creating Account...
+                </>
+              ) : (
+                'Create Account'
+              )}
+            </button>
           </form>
           <hr style={{ border: '0.5px solid rgba(255,255,255,0.1)', margin: '20px 0' }} />
           <div style={{ textAlign: 'center' }}>

--- a/fm-web/src/pages/Register.test.js
+++ b/fm-web/src/pages/Register.test.js
@@ -1,0 +1,155 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Register from './Register';
+import { AuthContext } from '../context/AuthContext';
+import * as ToastContextModule from '../context/ToastContext';
+import api, { getServers } from '../services/api';
+
+// Mock the API
+jest.mock('../services/api', () => {
+  const originalModule = jest.requireActual('../services/api');
+  return {
+    __esModule: true,
+    default: {
+        ...originalModule.default,
+        get: jest.fn(),
+        post: jest.fn(),
+    },
+    getServers: jest.fn(),
+  };
+});
+
+// Mock react-router-dom
+const mockedNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockedNavigate,
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+// Mock useToast
+const mockShowToast = jest.fn();
+jest.mock('../context/ToastContext', () => ({
+    useToast: () => ({
+        showToast: mockShowToast
+    })
+}));
+
+describe('Register Component', () => {
+  const login = jest.fn();
+
+  const renderComponent = () => {
+    render(
+      <AuthContext.Provider value={{ login }}>
+          <Register />
+      </AuthContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock initial data fetches
+    api.get.mockImplementation((url) => {
+        if (url === '/country/') {
+            return Promise.resolve({ data: [{ id: 1, name: 'Country A' }] });
+        }
+        return Promise.resolve({ data: [] });
+    });
+    getServers.mockResolvedValue({ data: [{ id: 1, name: 'Server A' }] });
+  });
+
+  test('renders register form with inputs associated with labels', async () => {
+    renderComponent();
+
+    // Wait for initial data load
+    await waitFor(() => expect(getServers).toHaveBeenCalled());
+
+    expect(screen.getByText('FM Register')).toBeInTheDocument();
+
+    // These checks verify that labels are correctly associated with inputs
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repeat Email address')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repeat Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Country')).toBeInTheDocument();
+    expect(screen.getByLabelText('Server')).toBeInTheDocument();
+    expect(screen.getByLabelText('Club Name')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+  });
+
+  test('handles successful registration', async () => {
+    api.post.mockResolvedValueOnce({ data: { token: 'fake-token' } });
+    renderComponent();
+
+    // Wait for initial data load
+    await waitFor(() => expect(getServers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'newuser' } });
+    fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText('Repeat Email address'), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password' } });
+    fireEvent.change(screen.getByLabelText('Repeat Password'), { target: { value: 'password' } });
+    fireEvent.change(screen.getByLabelText('Club Name'), { target: { value: 'My Club' } });
+
+    // Select country
+    fireEvent.change(screen.getByLabelText('Country'), { target: { value: '1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/user/register', expect.objectContaining({
+        username: 'newuser',
+        email: 'test@example.com',
+        clubName: 'My Club',
+        countryId: '1',
+        serverId: 1 // Default selected
+      }));
+      expect(login).toHaveBeenCalledWith({ token: 'fake-token' });
+      expect(mockedNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  test('displays loading state during submission', async () => {
+    // Mock API to delay response
+    api.post.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ data: { token: 'token' } }), 100)));
+    renderComponent();
+
+    await waitFor(() => expect(getServers).toHaveBeenCalled());
+
+    // Fill minimum required fields
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'user' } });
+    fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'e@e.com' } });
+    fireEvent.change(screen.getByLabelText('Repeat Email address'), { target: { value: 'e@e.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'p' } });
+    fireEvent.change(screen.getByLabelText('Repeat Password'), { target: { value: 'p' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    // This checks for the NEW behavior
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('Creating Account...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button')).not.toBeDisabled();
+      expect(screen.getByText('Create Account')).toBeInTheDocument();
+    });
+  });
+
+  test('validates passwords match', async () => {
+      renderComponent();
+      await waitFor(() => expect(getServers).toHaveBeenCalled());
+
+      fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'e@e.com' } });
+      fireEvent.change(screen.getByLabelText('Repeat Email address'), { target: { value: 'e@e.com' } });
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pass1' } });
+      fireEvent.change(screen.getByLabelText('Repeat Password'), { target: { value: 'pass2' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+      expect(mockShowToast).toHaveBeenCalledWith('Passwords do not match', 'error');
+      expect(api.post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎨 Palette: Improved Register Form UX

💡 **What:**
- Added a loading state to the "Create Account" button.
- Associated form labels with inputs using `htmlFor` and `id` attributes.
- Disabled form inputs during submission.
- Added a spinner and `aria-busy` attribute during loading.

🎯 **Why:**
- **Visual Feedback:** Users previously had no indication that their account was being created, leading to potential confusion or multiple submissions.
- **Accessibility:** Screen readers could not correctly associate labels with inputs, making the form difficult to navigate.
- **Usability:** Disabling inputs prevents users from changing data mid-submission.

📸 **Before/After:**
- **Before:** Static button, no label association.
- **After:** Button shows "Creating Account..." with a spinner, inputs are disabled, and labels are programmatically linked.

♿ **Accessibility:**
- Added `htmlFor` and `id` to all 6 form fields.
- Added `aria-busy="true"` to the submit button.
- Loading state is announced visually and programmatically.


---
*PR created automatically by Jules for task [8260562319058919420](https://jules.google.com/task/8260562319058919420) started by @lollito*