### PR TITLE
⚡ Bolt: Optimize ranking loading with EntityGraph

### DIFF
--- a/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
+++ b/src/main/java/com/lollito/fm/repository/rest/RankingRepository.java
@@ -17,4 +17,7 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
 	@EntityGraph(attributePaths = {"club"})
 	public java.util.List<Ranking> findBySeason(Season season);
+
+	@EntityGraph(attributePaths = {"club", "club.user"})
+	public java.util.List<Ranking> findBySeasonOrderByPointsDesc(Season season);
 }

--- a/src/main/java/com/lollito/fm/service/RankingService.java
+++ b/src/main/java/com/lollito/fm/service/RankingService.java
@@ -82,7 +82,7 @@ public class RankingService {
 	public List<Ranking> load(){
 		User user = userService.getLoggedUser();
 		if (user != null && user.getClub() != null) {
-			return user.getClub().getLeague().getCurrentSeason().getRankingLines();
+			return rankingLineRepository.findBySeasonOrderByPointsDesc(user.getClub().getLeague().getCurrentSeason());
 		}
 		return Collections.emptyList();
 	}

--- a/src/test/java/com/lollito/fm/service/RankingServicePerformanceTest.java
+++ b/src/test/java/com/lollito/fm/service/RankingServicePerformanceTest.java
@@ -23,6 +23,10 @@ import com.lollito.fm.repository.rest.MatchRepository;
 import com.lollito.fm.repository.rest.RankingRepository;
 import com.lollito.fm.repository.rest.RoundRepository;
 import com.lollito.fm.repository.rest.SeasonRepository;
+import com.lollito.fm.repository.rest.UserRepository;
+import com.lollito.fm.repository.rest.LeagueRepository;
+import com.lollito.fm.model.User;
+import com.lollito.fm.model.League;
 
 @SpringBootTest
 @Transactional
@@ -37,6 +41,79 @@ public class RankingServicePerformanceTest {
 	@Autowired SeasonRepository seasonRepository;
 	@Autowired MatchRepository matchRepository;
 	@Autowired RoundRepository roundRepository;
+	@Autowired UserRepository userRepository;
+	@Autowired LeagueRepository leagueRepository;
+
+	@Test
+	public void testLoad() {
+		// Create User if not exists
+		User user = userRepository.findByUsername("lollito").orElse(null);
+		if (user == null) {
+			user = new User();
+			user.setUsername("lollito");
+			user.setEmail("lollito@example.com");
+			user = userRepository.save(user);
+		}
+
+		// Create League
+		League league = new League();
+		league.setName("Test League");
+		league = leagueRepository.save(league);
+
+		// Create Season
+		Season season = new Season();
+		season.setName("2024");
+		season.setCurrent(true);
+		season.setLeague(league);
+		season = seasonRepository.save(season);
+
+		// Update League with Season (inverse side)
+		league.setCurrentSeason(season);
+		leagueRepository.save(league);
+
+		// Create Club for User
+		Club club = new Club();
+		club.setName("User Club");
+		club.setLeague(league);
+		club.setUser(user);
+		club = clubRepository.save(club);
+
+		// Update User with Club
+		user.setClub(club);
+		userRepository.save(user);
+
+		// Create Rankings
+		for (int i = 0; i < 5; i++) {
+			Club c = new Club();
+			c.setName("Club " + i);
+			c = clubRepository.save(c);
+
+			Ranking ranking = new Ranking();
+			ranking.setClub(c);
+			ranking.setSeason(season);
+			ranking.setPoints(i * 10); // 0, 10, 20, 30, 40
+			rankingRepository.save(ranking);
+		}
+
+		// Add user's club to ranking
+		Ranking userRanking = new Ranking();
+		userRanking.setClub(club);
+		userRanking.setSeason(season);
+		userRanking.setPoints(25);
+		rankingRepository.save(userRanking);
+
+		// Test load
+		List<Ranking> rankings = rankingService.load();
+
+		Assertions.assertNotNull(rankings);
+		Assertions.assertEquals(6, rankings.size());
+
+		// Verify Order (Points Descending)
+		Assertions.assertEquals(40, rankings.get(0).getPoints());
+		Assertions.assertEquals(30, rankings.get(1).getPoints());
+		Assertions.assertEquals(25, rankings.get(2).getPoints()); // User club
+		Assertions.assertEquals(20, rankings.get(3).getPoints());
+	}
 
 	@Test
 	public void testUpdateLoop() {


### PR DESCRIPTION
⚡ Bolt: Optimize ranking loading with EntityGraph

**💡 What:**
- Added `findBySeasonOrderByPointsDesc` to `RankingRepository` with `@EntityGraph(attributePaths = {"club", "club.user"})`.
- Refactored `RankingService.load()` to use this method directly instead of navigating `user.getClub().getLeague().getCurrentSeason().getRankingLines()`.

**🎯 Why:**
- The previous implementation triggered N+1 queries (actually 2N+1) when loading rankings:
    1. One query for rankings.
    2. N queries for `Club` (lazy loaded from Ranking).
    3. N queries for `User` (lazy loaded from Club, accessed by `ClubMapper` to determine `isHuman`).
- This caused performance degradation on the dashboard where rankings are displayed.

**📊 Impact:**
- Reduces database queries for ranking load from ~41 queries (for 20 clubs) to 1 query.
- Improves response time for the ranking API.

**🔬 Measurement:**
- Added `testLoad` in `RankingServicePerformanceTest` which verifies that `load()` returns the correct data and order.
- While specific query counts are hard to assert in integration tests without a proxy, the use of `@EntityGraph` is the standard solution for this pattern.

---
*PR created automatically by Jules for task [1721504753410083322](https://jules.google.com/task/1721504753410083322) started by @lollito*